### PR TITLE
memd 1.1.0: non-blocking HNSW repair (Issue 2) + cheap cold-start (Issue 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-15
+
+Makes the warm worker's index repair non-blocking, cuts HNSW cold-start cost,
+and adds embedding-device pinning and a prebuilt-first installer.
+
+### Added
+
+- **`MEMD_EMBED_DEVICE`**: pin the embedding device (`cpu`, `cuda`, `cuda:N`)
+  instead of always taking `cuda:0`, so memd can stay off a contended GPU on
+  shared machines.
+- **Prebuilt-first `make install`**: installs the released binary when it runs
+  on the host and compiles from source only as a fallback, so a first install
+  no longer requires a Rust toolchain.
+- **`warm status` repair signal**: the `ryw_probe` payload now reports
+  `repair_in_progress`, so an in-flight background index repair is observable.
+
+### Changed
+
+- **Non-blocking external-mutation repair**: when the warm worker detects an
+  external `metadata.db` mutation it now schedules a single-flight background
+  HNSW repair and serves the request after a short bounded wait, instead of
+  running the full backfill synchronously in the request path. Previously a
+  detected mutation could block a warm request for minutes and trip the client
+  timeout (notably on shared/NFS data directories). The worker still indexes
+  its own warm-routed writes synchronously, so same-worker read-your-writes is
+  unchanged; dense/hybrid coverage of externally-added chunks catches up once
+  the background repair lands (SQLite and sparse reads are immediate).
+- **Honest warm client-timeout message**: the timeout no longer asserts a
+  successful cold-path fallback that may not have happened; it points at the
+  worker log and `memd warm status`.
+
+### Fixed
+
+- **`add_batch` usage events**: batched adds now record per-chunk usage events
+  (mirroring single `add`), so the usefulness report and the central per-chunk
+  hit log no longer undercount batched writes.
+
+### Performance
+
+- **Cheap HNSW cold-start**: the cold-start backfill reuses persisted
+  embeddings (`embeddings.bin`) and re-embeds only the genuine delta via a
+  cache-aware membership check, instead of re-embedding every chunk from text.
+  A clean restart on a 140-chunk tenant drops from ~50 s to no re-embeds.
+
 ## [1.0.0] - 2026-06-11
 
 First stable release. Hardens retrieval recall, input validation, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memd"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anndists",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "evals/harness"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](Cargo.toml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-fmschulz.github.io%2Fmemd-blue)](https://fmschulz.github.io/memd/)

--- a/crates/memd/src/cli/warm.rs
+++ b/crates/memd/src/cli/warm.rs
@@ -1186,8 +1186,10 @@ fn validate_warm_worker_identity(result: &Value) -> Result<()> {
 
 #[cfg(unix)]
 /// Client-side timeout for a single warm-worker request. A wedged worker (e.g.
-/// one blocked on the SQLite busy_timeout) must not hang the CLI indefinitely;
-/// on timeout the request fails and `--warm auto` falls back to the cold path.
+/// one blocked on the SQLite busy_timeout) must not hang the CLI indefinitely.
+/// On timeout the request FAILS and the error propagates (there is no automatic
+/// cold-path fallback); the worker is often not wedged but busy repairing
+/// indexes — see the timeout message below.
 fn warm_client_timeout() -> Duration {
     std::env::var("MEMD_WARM_CLIENT_TIMEOUT_MS")
         .ok()
@@ -1256,8 +1258,9 @@ async fn warm_request(socket: &Path, request: &WarmWireRequest) -> Result<WarmWi
     match tokio::time::timeout(timeout, exchange).await {
         Ok(result) => result,
         Err(_elapsed) => Err(MemdError::ProtocolError(format!(
-            "warm worker did not respond within {} ms; falling back to the cold path \
-             (adjust with MEMD_WARM_CLIENT_TIMEOUT_MS or stop it with `memd warm stop`)",
+            "warm worker did not respond within {} ms; it may be busy repairing indexes \
+             (check the worker log via `memd warm status`). Raise MEMD_WARM_CLIENT_TIMEOUT_MS, \
+             retry with `--warm off`, or stop it with `memd warm stop`.",
             timeout.as_millis()
         ))),
     }

--- a/crates/memd/src/cli/warm.rs
+++ b/crates/memd/src/cli/warm.rs
@@ -1159,6 +1159,7 @@ fn warm_worker_identity(socket: &Path, ryw_probe_stats: Option<RywProbeStats>) -
             "checks": stats.checks,
             "external_detected": stats.external_detected,
             "repairs": stats.repairs,
+            "repair_in_progress": stats.repair_in_progress,
         });
     }
     identity
@@ -1588,6 +1589,7 @@ mod tests {
                 checks: 3,
                 external_detected: 1,
                 repairs: 1,
+                repair_in_progress: false,
             }),
         );
 

--- a/crates/memd/src/store/dense.rs
+++ b/crates/memd/src/store/dense.rs
@@ -415,6 +415,47 @@ impl DenseSearcher {
         })
     }
 
+    /// Ensure the tenant's persisted HNSW index (mapping + embedding cache)
+    /// is loaded into memory. The backfill calls this before deciding what is
+    /// "missing", so a clean persisted index is not needlessly re-embedded.
+    pub(crate) fn ensure_index_loaded(&self, tenant_id: &TenantId) -> Result<()> {
+        self.get_or_create_index(tenant_id)?;
+        Ok(())
+    }
+
+    /// Of `chunk_ids`, return those WITHOUT a live cached embedding in the
+    /// loaded index — no mapping entry, OR a mapping entry whose embedding
+    /// cache slot is empty (e.g. after a missing/corrupt `embeddings.bin`,
+    /// where the loader keeps the mapping but resets the cache). Takes the
+    /// per-tenant locks once. If the index is not loaded, every chunk is
+    /// reported missing — callers should `ensure_index_loaded` first.
+    ///
+    /// This is the cache-aware membership the backfill needs: `contains_chunk`
+    /// (mapping-only) would wrongly treat cache-less chunks as present and
+    /// skip re-embedding them, leaving the index without usable vectors.
+    pub(crate) fn chunks_missing_embeddings(
+        &self,
+        tenant_id: &TenantId,
+        chunk_ids: &[ChunkId],
+    ) -> Vec<ChunkId> {
+        let indices = self.indices.read();
+        let Some(index) = indices.get(&tenant_id.to_string()) else {
+            return chunk_ids.to_vec();
+        };
+        let mapping = index.get_mapping().read();
+        let cache = index.get_embedding_cache().read();
+        chunk_ids
+            .iter()
+            .filter(|chunk_id| {
+                mapping
+                    .get_internal_id(chunk_id)
+                    .and_then(|internal_id| cache.get(internal_id))
+                    .is_none()
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Embed a query text (exposes embedder for tiered search)
     pub async fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
         self.embedder.embed_query(text).await

--- a/crates/memd/src/store/mod.rs
+++ b/crates/memd/src/store/mod.rs
@@ -114,7 +114,14 @@ pub enum ExternalMutationOutcome {
     Unavailable,
     Clean,
     OwnWrites,
-    External { repaired: bool },
+    /// An external metadata.db mutation was observed. `repaired` is true when
+    /// the follow-up HNSW repair completed within the warm request's bounded
+    /// foreground budget; it is false when the repair was left to finish in
+    /// the background (or one was already running), in which case `warm
+    /// status` reports `repair_in_progress`.
+    External {
+        repaired: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -122,6 +129,8 @@ pub struct RywProbeStats {
     pub checks: u64,
     pub external_detected: u64,
     pub repairs: u64,
+    /// True when a store-owned HNSW repair is currently running.
+    pub repair_in_progress: bool,
 }
 
 pub(crate) fn score_candidate_chunk(query: &str, chunk: &MemoryChunk) -> f32 {

--- a/crates/memd/src/store/persistent.rs
+++ b/crates/memd/src/store/persistent.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 
 use parking_lot::{Mutex, RwLock};
 use rusqlite::{Connection as ProbeConnection, OpenFlags};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
@@ -218,6 +218,11 @@ pub struct PersistentStore {
     write_epoch: Arc<AtomicU64>,
     /// Warn-only detector for metadata.db changes not attributable to this store.
     external_mutation_probe: Option<ExternalMutationProbe>,
+    /// Shared single-flight state + telemetry for store-owned HNSW repairs.
+    repair_state: Arc<HnswRepairState>,
+    /// JoinHandle of the most recent store-owned HNSW repair, aborted on
+    /// shutdown/Drop so a repair can never race the dense index-save.
+    repair_task: Mutex<Option<JoinHandle<()>>>,
     /// Last time this store attempted a usage-ledger retention sweep.
     usage_sweep_last_ms: AtomicI64,
     /// Process-wide exclusive writer lock. Last field so it drops last.
@@ -312,6 +317,121 @@ struct AsyncIndexerHandle {
     task: JoinHandle<()>,
 }
 
+/// Foreground wait budget for an on-probe HNSW repair. After this elapses
+/// the warm request is served anyway and the store-owned repair keeps
+/// running in the background. Kept well under the warm client timeout so a
+/// detected external mutation can never stall a request for minutes.
+const HNSW_REPAIR_FOREGROUND_BUDGET: Duration = Duration::from_millis(1500);
+
+/// Shared, single-flight state for store-owned HNSW repairs, shared by the
+/// startup backfill and on-probe repairs so the two can never index the same
+/// `missing` set concurrently (`run_hnsw_backfill` snapshots `missing` before
+/// inserting, so overlapping runs would double-index).
+///
+/// `inner` is a brief-hold bookkeeping lock (never held across the backfill
+/// await). `pending` re-arms the running repair: when a probe detects a fresh
+/// external mutation while a repair is already running, the in-flight repair's
+/// metadata snapshot may predate that write, so we flag that one more pass is
+/// required rather than dropping the coalesced signal (the probe has already
+/// advanced its `data_version`, so no later probe would re-detect it).
+#[derive(Debug, Default)]
+struct HnswRepairState {
+    inner: Mutex<RepairBookkeeping>,
+    /// Count of completed probe-triggered repair passes, surfaced via `warm
+    /// status`. Startup backfills are not counted as repairs.
+    repairs: AtomicU64,
+}
+
+#[derive(Debug, Default)]
+struct RepairBookkeeping {
+    /// True while a repair task owns the single-flight slot.
+    in_flight: bool,
+    /// True when an external mutation was observed during an in-flight repair
+    /// and a follow-up pass is required to cover writes added after its
+    /// snapshot.
+    pending: bool,
+}
+
+impl HnswRepairState {
+    /// Try to claim the single-flight slot. Returns `true` if the caller
+    /// became the owner and must spawn the repair; `false` if a repair is
+    /// already running (a probe additionally re-arms `pending` so the running
+    /// repair does a follow-up pass).
+    fn try_begin_or_arm(&self, kind: RepairKind) -> bool {
+        let mut g = self.inner.lock();
+        if g.in_flight {
+            if kind == RepairKind::Probe {
+                g.pending = true;
+            }
+            false
+        } else {
+            g.in_flight = true;
+            g.pending = false;
+            true
+        }
+    }
+
+    /// Called by the repair task after each pass. Returns `true` if another
+    /// pass is required (an external mutation was observed mid-pass); returns
+    /// `false` after releasing the slot when no follow-up is pending. All
+    /// transitions are under the same lock as `try_begin_or_arm`, so a probe
+    /// that arms `pending` after the slot is released instead becomes the next
+    /// owner — no signal is lost.
+    fn finish_or_continue(&self) -> bool {
+        let mut g = self.inner.lock();
+        if g.pending {
+            g.pending = false;
+            true
+        } else {
+            g.in_flight = false;
+            false
+        }
+    }
+
+    fn repair_in_progress(&self) -> bool {
+        self.inner.lock().in_flight
+    }
+}
+
+/// Panic-safety reset for the single-flight slot. The repair task defuses it
+/// (`armed = false`) on normal exit, where `finish_or_continue` has already
+/// released the slot; if the task panics or is aborted mid-pass the guard runs
+/// and frees the slot so future repairs aren't wedged.
+struct RepairInFlightGuard {
+    state: Arc<HnswRepairState>,
+    armed: bool,
+}
+
+impl Drop for RepairInFlightGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let mut g = self.state.inner.lock();
+            g.in_flight = false;
+            g.pending = false;
+        }
+    }
+}
+
+/// Why a repair was scheduled. Only probe-triggered repairs bump the
+/// `repairs` telemetry counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepairKind {
+    Startup,
+    Probe,
+}
+
+/// Result of trying to schedule a store-owned HNSW repair.
+enum RepairSchedule {
+    /// This call won the single-flight race and spawned the repair. The
+    /// receiver resolves to `true` on success / `false` on error once the
+    /// repair finishes.
+    Scheduled(oneshot::Receiver<bool>),
+    /// A repair was already running; this call scheduled nothing.
+    AlreadyInFlight,
+    /// Nothing to schedule: no async runtime (sync test context).
+    Skipped,
+}
+
 struct IndexJob {
     tenant_id: TenantId,
     chunk_ids: Vec<ChunkId>,
@@ -324,7 +444,6 @@ struct ExternalMutationProbe {
     write_epoch: Arc<AtomicU64>,
     checks: AtomicU64,
     external_detected: AtomicU64,
-    repairs: AtomicU64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -359,7 +478,6 @@ impl ExternalMutationProbe {
             write_epoch,
             checks: AtomicU64::new(0),
             external_detected: AtomicU64::new(0),
-            repairs: AtomicU64::new(0),
         })
     }
 
@@ -404,15 +522,13 @@ impl ExternalMutationProbe {
         Ok(check)
     }
 
-    fn record_repair(&self) {
-        self.repairs.fetch_add(1, Ordering::Relaxed);
-    }
-
     fn stats(&self) -> RywProbeStats {
+        // `repairs` / `repair_in_progress` are owned by `HnswRepairState`
+        // and filled in by `PersistentStore::ryw_probe_stats`.
         RywProbeStats {
             checks: self.checks.load(Ordering::Relaxed),
             external_detected: self.external_detected.load(Ordering::Relaxed),
-            repairs: self.repairs.load(Ordering::Relaxed),
+            ..RywProbeStats::default()
         }
     }
 
@@ -622,6 +738,8 @@ impl PersistentStore {
             async_indexer: None,
             write_epoch,
             external_mutation_probe,
+            repair_state: Arc::new(HnswRepairState::default()),
+            repair_task: Mutex::new(None),
             usage_sweep_last_ms: AtomicI64::new(usage_sweep_initial_ms),
             _writer_lock: writer_lock,
         };
@@ -648,44 +766,99 @@ impl PersistentStore {
     /// Tokio runtime is available (e.g., sync test contexts) — callers
     /// can invoke `backfill_hnsw_for_cold_tenants` explicitly in that case.
     fn spawn_startup_hnsw_backfill(&self) {
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(h) => h,
-            Err(_) => {
-                // Test / sync context. The caller who wants backfill can
-                // call `backfill_hnsw_for_cold_tenants` directly.
-                return;
-            }
+        // Routed through the shared single-flight scheduler so a startup
+        // backfill and an on-probe repair can never double-index the same
+        // `missing` set. Fire-and-forget: the returned handle is tracked in
+        // `repair_task` for abort-on-shutdown.
+        let _ = self.schedule_hnsw_repair(RepairKind::Startup);
+    }
+
+    /// Spawn a store-owned, single-flight HNSW repair and return a handle to
+    /// its completion. Shared by the startup backfill and the on-probe
+    /// repair: only the thread that flips the single-flight flag gets to
+    /// spawn, so overlapping runs can't double-index. The spawned task owns
+    /// its `JoinHandle` (stored in `repair_task`) so `shutdown`/`Drop` can
+    /// abort it before the dense index-save. `RepairInFlightGuard` resets the
+    /// flag on every exit path of the task, including a panic.
+    fn schedule_hnsw_repair(&self, kind: RepairKind) -> RepairSchedule {
+        // Best-effort: with no Tokio runtime (sync test context) there is
+        // nothing to spawn onto. A caller that needs the backfill in that
+        // case calls `backfill_hnsw_for_cold_tenants` directly.
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => return RepairSchedule::Skipped,
         };
 
+        // Single-flight: only the owner spawns. A concurrent startup backfill
+        // or probe repair backs off; a probe additionally arms `pending` so the
+        // running repair does a follow-up pass covering writes that landed after
+        // its metadata snapshot (otherwise the coalesced signal — whose
+        // `data_version` the probe already advanced — would be lost).
+        if !self.repair_state.try_begin_or_arm(kind) {
+            return RepairSchedule::AlreadyInFlight;
+        }
+
+        let state = Arc::clone(&self.repair_state);
+        let guard = RepairInFlightGuard {
+            state: Arc::clone(&self.repair_state),
+            armed: true,
+        };
         let dense_searcher = self.dense_searcher.clone();
         let hybrid_searcher = self.hybrid_searcher.clone();
         let metadata = Arc::clone(&self.metadata);
         let tenants = Arc::clone(&self.tenants);
+        let (tx, rx) = oneshot::channel::<bool>();
 
-        handle.spawn(async move {
-            match run_hnsw_backfill(
-                dense_searcher.as_ref(),
-                hybrid_searcher.as_ref(),
-                metadata.as_ref(),
-                tenants.as_ref(),
-            )
-            .await
-            {
-                Ok(stats) => {
-                    if stats.tenants_backfilled > 0 || stats.chunks_indexed > 0 {
-                        info!(
-                            tenants = stats.tenants_backfilled,
-                            chunks = stats.chunks_indexed,
-                            skipped = stats.chunks_skipped,
-                            "startup HNSW backfill completed"
-                        );
+        let task = runtime.spawn(async move {
+            let mut guard = guard; // owned by the task; defused on normal exit
+                                   // Drain loop: repeat while probes keep arming `pending`, so a write
+                                   // that arrives after one pass's snapshot is picked up by the next.
+                                   // The loop yields the final pass's outcome.
+            let final_ok = loop {
+                let ok = match run_hnsw_backfill(
+                    dense_searcher.as_ref(),
+                    hybrid_searcher.as_ref(),
+                    metadata.as_ref(),
+                    tenants.as_ref(),
+                )
+                .await
+                {
+                    Ok(stats) => {
+                        // Count only probe-triggered repairs; a startup backfill
+                        // is not a "repair" for telemetry purposes.
+                        if kind == RepairKind::Probe {
+                            state.repairs.fetch_add(1, Ordering::Relaxed);
+                        }
+                        if stats.tenants_backfilled > 0 || stats.chunks_indexed > 0 {
+                            info!(
+                                kind = ?kind,
+                                tenants = stats.tenants_backfilled,
+                                chunks = stats.chunks_indexed,
+                                skipped = stats.chunks_skipped,
+                                "store-owned HNSW repair completed"
+                            );
+                        }
+                        true
                     }
+                    Err(e) => {
+                        warn!(kind = ?kind, error = %e, "store-owned HNSW repair failed");
+                        false
+                    }
+                };
+                if !state.finish_or_continue() {
+                    break ok;
                 }
-                Err(e) => {
-                    warn!(error = %e, "startup HNSW backfill failed");
-                }
-            }
+            };
+            guard.armed = false; // normal exit: the slot is already released
+                                 // The receiver is gone if the foreground budget already elapsed;
+                                 // that is the expected non-blocking case, so ignore send errors.
+            let _ = tx.send(final_ok);
         });
+
+        // Track the handle so shutdown/Drop can abort the repair before the
+        // dense index-save. Replaces any prior (already-finished) handle.
+        *self.repair_task.lock() = Some(task);
+        RepairSchedule::Scheduled(rx)
     }
 
     pub fn async_indexing_enabled(&self) -> bool {
@@ -792,26 +965,37 @@ impl PersistentStore {
                 warn!(
                     prev_data_version,
                     data_version,
-                    "external metadata.db mutation detected while holding the writer lock; refreshing indexes"
+                    "external metadata.db mutation detected while holding the writer lock; scheduling background HNSW repair"
                 );
-                // Sparse/tantivy needs no action here: `SparseIndex::search()`
-                // already does `commit_if_dirty` + `reader.reload()` per
-                // query, and read paths hit SQLite directly. The repair seam
-                // refreshes in-memory HNSW coverage for chunks now present in
-                // metadata.
-                match self.backfill_hnsw_for_cold_tenants().await {
-                    Ok(_) => {
-                        probe.record_repair();
-                        ExternalMutationOutcome::External { repaired: true }
-                    }
-                    Err(error) => {
-                        warn!(
-                            error = %error,
-                            "failed to repair after external metadata.db mutation"
-                        );
-                        ExternalMutationOutcome::External { repaired: false }
-                    }
-                }
+                // Do NOT await the backfill in the foreground request path: on
+                // a large or cold tenant it can run for minutes and trip the
+                // warm client timeout. Schedule a store-owned, single-flight
+                // repair and wait only a bounded budget for it to finish; if it
+                // is still running when the budget elapses we serve the request
+                // anyway and the repair continues in the background.
+                //
+                // Freshness relaxation: when we serve before the repair lands,
+                // this one request's dense/hybrid results may miss chunks that
+                // another writer just added. Sparse/tantivy is unaffected
+                // (`SparseIndex::search()` does `commit_if_dirty` +
+                // `reader.reload()` per query) and SQLite reads hit metadata
+                // directly, so those paths stay correct. Same-worker
+                // read-your-writes is also unaffected — our own writes index on
+                // the synchronous write path.
+                // `repaired` is true only when the repair finished within the
+                // bounded budget. A repair that is still running, was already
+                // in flight, or was skipped serves now with `repaired: false`;
+                // `warm status` reflects an ongoing repair via
+                // `repair_in_progress`. Timing out the wait drops only the
+                // receiver — the spawned repair task runs to completion.
+                let repaired = match self.schedule_hnsw_repair(RepairKind::Probe) {
+                    RepairSchedule::Scheduled(rx) => matches!(
+                        tokio::time::timeout(HNSW_REPAIR_FOREGROUND_BUDGET, rx).await,
+                        Ok(Ok(true))
+                    ),
+                    RepairSchedule::AlreadyInFlight | RepairSchedule::Skipped => false,
+                };
+                ExternalMutationOutcome::External { repaired }
             }
             Err(error) => {
                 warn!(
@@ -824,9 +1008,11 @@ impl PersistentStore {
     }
 
     pub fn ryw_probe_stats(&self) -> Option<RywProbeStats> {
-        self.external_mutation_probe
-            .as_ref()
-            .map(ExternalMutationProbe::stats)
+        let probe = self.external_mutation_probe.as_ref()?;
+        let mut stats = probe.stats();
+        stats.repairs = self.repair_state.repairs.load(Ordering::Relaxed);
+        stats.repair_in_progress = self.repair_state.repair_in_progress();
+        Some(stats)
     }
 
     fn start_async_indexer_if_enabled(&self) -> Option<AsyncIndexerHandle> {
@@ -1242,6 +1428,27 @@ impl PersistentStore {
         if self.config.read_only {
             tracing::debug!("read-only PersistentStore shutdown skips persistence writes");
             return Ok(());
+        }
+
+        // Stop any in-flight store-owned HNSW repair before saving indices, so
+        // the repair does not concurrently mutate the dense index while
+        // `save_all()` serializes it. `abort()` is cooperative (the task stops
+        // at its next await), so wait a bounded moment for it to unwind: on the
+        // multi-threaded warm-worker runtime the aborted task is cancelled on
+        // another worker thread and clears the slot well within this budget,
+        // giving a real barrier. If it does not clear in time (e.g. a
+        // single-worker runtime that cannot poll the aborted task while this
+        // thread blocks) we fall through best-effort — the dense index is
+        // internally locked so the save cannot tear, and any batch not yet
+        // persisted is re-indexed cheaply by the cache-aware backfill on the
+        // next start.
+        let repair_task = self.repair_task.lock().take();
+        if let Some(task) = repair_task {
+            task.abort();
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while self.repair_state.repair_in_progress() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
         }
 
         // Save dense indices
@@ -3998,6 +4205,10 @@ mod tests {
             wal_checkpoint_interval: 10,
             enable_dense_search: false, // Disable for unit tests
             enable_hybrid_search: false,
+            // Keep the shared single-flight slot free at open() so probe/repair
+            // tests are deterministic (a startup backfill would otherwise hold
+            // the in-flight flag until the first runtime poll).
+            backfill_hnsw_on_startup: false,
             ..Default::default()
         };
         let store = PersistentStore::open(config).unwrap();
@@ -4104,6 +4315,10 @@ mod tests {
             .unwrap();
         drop(conn);
 
+        // The repair is now scheduled as a store-owned background task rather
+        // than awaited in the foreground. With dense search disabled the
+        // backfill is an instant no-op, so it finishes within the foreground
+        // budget and reports `repaired: true`; `repairs` is counted on completion.
         assert_eq!(
             store.probe_external_mutation().await,
             ExternalMutationOutcome::External { repaired: true }
@@ -4112,6 +4327,7 @@ mod tests {
         assert_eq!(stats.checks, 2);
         assert_eq!(stats.external_detected, 1);
         assert_eq!(stats.repairs, 1);
+        assert!(!stats.repair_in_progress);
     }
 
     #[tokio::test]
@@ -4142,6 +4358,90 @@ mod tests {
             ExternalMutationOutcome::Unavailable
         );
         assert_eq!(store.ryw_probe_stats(), None);
+    }
+
+    #[tokio::test]
+    async fn hnsw_repair_is_single_flight() {
+        let (store, _dir) = make_test_store();
+
+        // The first schedule wins the single-flight race and spawns the
+        // repair; a second schedule issued before the task is polled sees the
+        // in-flight flag and schedules nothing. (Current-thread test runtime:
+        // the spawned task does not run until the await below.)
+        let first = store.schedule_hnsw_repair(RepairKind::Probe);
+        let second = store.schedule_hnsw_repair(RepairKind::Probe);
+        assert!(matches!(first, RepairSchedule::Scheduled(_)));
+        assert!(matches!(second, RepairSchedule::AlreadyInFlight));
+
+        // Draining the first repair resets the flag, so a later schedule wins
+        // again — the guard is not stuck after completion.
+        if let RepairSchedule::Scheduled(rx) = first {
+            assert!(matches!(rx.await, Ok(true)));
+        }
+        assert!(!store.repair_state.repair_in_progress());
+        let third = store.schedule_hnsw_repair(RepairKind::Probe);
+        assert!(matches!(third, RepairSchedule::Scheduled(_)));
+    }
+
+    #[tokio::test]
+    async fn probe_does_not_block_when_repair_in_flight() {
+        let (store, dir) = make_test_store();
+
+        // Occupy the single-flight slot with a repair that has not been polled
+        // yet (holding its handle keeps the in-flight flag set on the
+        // current-thread runtime until we await).
+        let _held = store.schedule_hnsw_repair(RepairKind::Probe);
+        assert!(store.repair_state.repair_in_progress());
+
+        // Make metadata.db look externally mutated.
+        let conn = Connection::open(dir.path().join("metadata.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ryw_probe_inflight_test(x INTEGER)",
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO ryw_probe_inflight_test(x) VALUES (1)", [])
+            .unwrap();
+        drop(conn);
+
+        // The probe detects the external mutation but a repair is already
+        // running, so it serves immediately as `InFlight` instead of
+        // scheduling or blocking on another backfill.
+        assert_eq!(
+            store.probe_external_mutation().await,
+            ExternalMutationOutcome::External { repaired: false }
+        );
+        assert!(store.ryw_probe_stats().unwrap().repair_in_progress);
+    }
+
+    #[test]
+    fn repair_bookkeeping_rearms_pending_then_releases() {
+        let state = HnswRepairState::default();
+
+        // First owner claims the single-flight slot.
+        assert!(state.try_begin_or_arm(RepairKind::Probe));
+        assert!(state.repair_in_progress());
+
+        // A probe arriving mid-repair is coalesced but arms a follow-up pass
+        // (this is the regression guard: the signal must not be dropped).
+        assert!(!state.try_begin_or_arm(RepairKind::Probe));
+
+        // The running repair sees `pending` and must do another pass; the slot
+        // stays held so no second task can start.
+        assert!(state.finish_or_continue());
+        assert!(state.repair_in_progress());
+
+        // No further arming -> the next finish releases the slot.
+        assert!(!state.finish_or_continue());
+        assert!(!state.repair_in_progress());
+
+        // A startup backfill losing the race does NOT arm a follow-up pass
+        // (only externally-observed writes need one).
+        assert!(state.try_begin_or_arm(RepairKind::Probe));
+        assert!(!state.try_begin_or_arm(RepairKind::Startup));
+        assert!(!state.finish_or_continue());
+        assert!(!state.repair_in_progress());
     }
 
     fn make_long_document() -> String {

--- a/crates/memd/src/store/persistent.rs
+++ b/crates/memd/src/store/persistent.rs
@@ -2758,13 +2758,36 @@ async fn run_hnsw_backfill(
             continue;
         }
 
-        // Per-chunk membership is the authoritative cold signal.
-        // Count-only heuristics fail when HNSW's `next_id` has grown past
-        // the active count due to deletes (dense deletes never decrement
-        // the counter).
+        // Load the persisted index (mapping + embedding cache) BEFORE deciding
+        // what is missing. The per-tenant index is created lazily on first
+        // search/index, so without this a clean persisted tenant looks 100%
+        // missing and we needlessly re-embed every chunk. Best-effort: a load
+        // failure leaves the index empty, so the cache-aware check below
+        // reports all chunks missing and we re-embed (today's safe fallback).
+        if let Err(e) = dense.ensure_index_loaded(&tenant_id) {
+            warn!(
+                tenant_id = %tenant_id,
+                error = %e,
+                "HNSW backfill: failed to load persisted index; treating all chunks as missing"
+            );
+        }
+
+        // Cache-aware membership is the authoritative cold signal: a chunk is
+        // "missing" only when it has no LIVE cached embedding (no mapping
+        // entry, or a mapping entry whose embedding-cache slot is empty after a
+        // missing/corrupt embeddings.bin). Mapping-only membership
+        // (`contains_chunk`) would treat cache-less chunks as present and skip
+        // re-embedding them, leaving the HNSW without usable vectors. Count
+        // heuristics also fail when `next_id` grew past the active count due to
+        // deletes (dense deletes never decrement the counter).
+        let all_ids: Vec<ChunkId> = metas.iter().map(|m| m.chunk_id.clone()).collect();
+        let missing_ids: std::collections::HashSet<ChunkId> = dense
+            .chunks_missing_embeddings(&tenant_id, &all_ids)
+            .into_iter()
+            .collect();
         let missing: Vec<_> = metas
             .into_iter()
-            .filter(|m| !dense.contains_chunk(&tenant_id, &m.chunk_id))
+            .filter(|m| missing_ids.contains(&m.chunk_id))
             .collect();
 
         if missing.is_empty() {
@@ -5312,6 +5335,68 @@ mod tests {
             stats
         );
         assert_eq!(stats.tenants_backfilled, 1);
+    }
+
+    #[tokio::test]
+    async fn chunks_missing_embeddings_is_cache_aware() {
+        // The backfill's cold signal is cache-aware membership: a chunk counts
+        // as "missing" only when it has no live cached embedding. Indexed
+        // chunks (mapping + cache) are NOT missing; unindexed chunk ids ARE;
+        // and a tenant whose index is not loaded reports every id missing.
+        use crate::embeddings::MockEmbedder;
+        use crate::store::dense::{DenseSearchConfig, DenseSearcher};
+
+        let dir = tempdir().unwrap();
+        let config = PersistentStoreConfig {
+            data_dir: dir.path().to_path_buf(),
+            enable_dense_search: true,
+            enable_hybrid_search: false,
+            enable_tiered_search: false,
+            ..Default::default()
+        };
+        let mut store = PersistentStore::open(config).unwrap();
+        let embedder = Arc::new(MockEmbedder::new());
+        let dense = Arc::new(DenseSearcher::with_embedder(
+            Arc::clone(&embedder) as Arc<dyn crate::embeddings::Embedder>,
+            DenseSearchConfig {
+                persist: false,
+                ..Default::default()
+            },
+        ));
+        store.dense_searcher = Some(Arc::clone(&dense));
+
+        let tenant = make_tenant();
+        let id1 = Store::add(&store, make_chunk(&tenant, "indexed one"))
+            .await
+            .unwrap();
+        let id2 = Store::add(&store, make_chunk(&tenant, "indexed two"))
+            .await
+            .unwrap();
+
+        // Both added chunks have live cached embeddings → neither is missing.
+        assert!(
+            dense
+                .chunks_missing_embeddings(&tenant, &[id1.clone(), id2.clone()])
+                .is_empty(),
+            "indexed chunks must not be reported missing"
+        );
+
+        // A fabricated id that was never indexed IS missing.
+        let ghost = ChunkId::new();
+        assert_eq!(
+            dense.chunks_missing_embeddings(&tenant, &[id1.clone(), ghost.clone()]),
+            vec![ghost],
+            "only the unindexed chunk is missing"
+        );
+
+        // A tenant with no loaded index reports every id missing (the cold
+        // case the backfill resolves by `ensure_index_loaded` first).
+        let other = TenantId::new("other_tenant").unwrap();
+        assert_eq!(
+            dense.chunks_missing_embeddings(&other, &[id1.clone()]),
+            vec![id1],
+            "unloaded tenant reports all ids missing"
+        );
     }
 
     #[tokio::test]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
+[![Version](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](https://github.com/fmschulz/memd/blob/main/Cargo.toml){ .md-button }
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/fmschulz/memd/blob/main/LICENSE){ .md-button }
 

--- a/docs/shared-topology.md
+++ b/docs/shared-topology.md
@@ -66,8 +66,12 @@ directories or `metadata.db`; mutating operations on a ReadOnly store return a
 typed error.
 
 The worker probes SQLite `data_version` before each request. If an external
-direct-fallback mutation happened, it refreshes indexes before serving so
-read-your-writes holds across warm and direct-write paths.
+direct-fallback mutation happened, it schedules a single-flight background HNSW
+repair and serves the request without blocking on it (waiting only a short
+bounded budget rather than the full backfill). SQLite and sparse reads reflect
+the external write immediately; dense/hybrid coverage of externally-added chunks
+catches up once the background repair lands. The worker always indexes its own
+warm-routed writes synchronously, so same-worker read-your-writes is unaffected.
 Measured on the dev machine (2026-06, hardening validation run): an 8-writer × 3-round
 write storm leaves 24/24 concurrent writes readable (7 of 16 were lost in the
 2026-06-09 audit before the writer lock); warm-routed `memd add` p50 is 31 ms (vs ~1.6 s cold); a write is

--- a/tools/wiki/pyproject.toml
+++ b/tools/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memd-wiki"
-version = "1.0.0"
+version = "1.1.0"
 description = "Deterministic compiled markdown wiki over memd project state."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Releases **memd 1.1.0**. Two HNSW-backfill defects in the warm worker, plus the version bump.

- **Issue 1 (perf)** — cold-start backfill reused persisted embeddings instead of re-embedding every chunk from text. A clean restart drops from ~50s to no re-embeds (`c32ab4d`).
- **Issue 2 (fix)** — `probe_external_mutation` awaited the backfill synchronously, so a warm request that observed an external `metadata.db` mutation blocked for the full repair (minutes on shared/NFS dirs) and tripped the client timeout. The repair now runs as a store-owned, single-flight background task; the request is served after a bounded foreground budget (`ae5cd0e`).

## Issue 2 design

- bounded budget waits on a oneshot, never on the backfill future, so timing out the wait can't cancel repair work
- shared single-flight with the startup backfill (no double-index)
- re-arm/pending **drain loop**: a probe coalesced mid-repair triggers a follow-up pass, so a write landing after the running repair's snapshot isn't dropped
- repair task bounded-joined in `shutdown()` before the dense index-save
- `warm status` surfaces `repair_in_progress`
- **public API unchanged** (`ExternalMutationOutcome::External { repaired }` kept) → 1.0.0 → 1.1.0 minor

## Test plan

- full suite green; `cargo fmt` + clippy clean (no new warnings)
- new tests: `hnsw_repair_is_single_flight`, `probe_does_not_block_when_repair_in_flight`, `repair_bookkeeping_rearms_pending_then_releases`
- 3 independent Codex review rounds (P1 dropped-signal + P2 shutdown-race found and fixed)
- live e2e against the installed binary: external mutation detected, **17ms non-blocking read**, background repair completed (`repairs=1`)
- `cargo publish -p memd --dry-run` packaged + verified `memd v1.1.0`

## Release

CHANGELOG 1.1.0 covers Issue 1+2, `MEMD_EMBED_DEVICE`, the prebuilt-first installer, and the `add_batch` usage fix. Merging to `main` triggers `auto-release.yml` → cargo-dist `release.yml` (4-platform GitHub release) → `publish-crate.yml` (crates.io).