### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-17
+
+Bounds warm-worker memory so a misconfigured idle timeout can no longer
+accumulate resident workers until the host runs out of memory.
+
+### Fixed
+
+- **Warm-worker accumulation / OOM**: the warm worker keeps the embedding model
+  (~400 MB on CPU) resident, and the idle timeout was the *only* reaper for
+  idle/orphaned workers. With `MEMD_WARM_IDLE_TIMEOUT_SECS=0` every per-data-dir
+  worker became immortal, so many ephemeral data dirs (e.g. per-test / per-run
+  `.memd` directories) could pile up hundreds of workers and exhaust host RAM.
+  Three independent guards now prevent this and make `idle=0` safe again:
+  - a resident-worker **cap** (`MEMD_WARM_MAX_WORKERS`, default 16, cannot be
+    disabled): `warm start` refuses to spawn beyond the cap and the client falls
+    back to the cold path (or errors under `--warm required`);
+  - **idle-independent orphan eviction**: a worker whose published pid file no
+    longer names it has been replaced (bind+rename race) and exits within ~60 s,
+    even when the idle reaper is disabled;
+  - an **ephemeral-data-dir guard**: auto-warm is skipped for `pytest-of-` data
+    dirs (the accumulation vector), overridable with `MEMD_WARM_ALLOW_EPHEMERAL=1`.
+
+### Added
+
+- **`MEMD_WARM_MAX_WORKERS`**: hard ceiling on concurrent warm workers (default
+  16); `0` or an invalid value falls back to the default — the cap cannot be
+  disabled.
+- **`MEMD_WARM_ALLOW_EPHEMERAL`**: opt ephemeral (`pytest-of-`) data dirs back
+  into auto-warm.
+
 ## [1.1.0] - 2026-06-15
 
 Makes the warm worker's index repair non-blocking, cuts HNSW cold-start cost,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memd"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anndists",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "evals/harness"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.1-blue)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](Cargo.toml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-fmschulz.github.io%2Fmemd-blue)](https://fmschulz.github.io/memd/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
+[![Version](https://img.shields.io/badge/version-1.1.1-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](https://github.com/fmschulz/memd/blob/main/Cargo.toml){ .md-button }
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/fmschulz/memd/blob/main/LICENSE){ .md-button }
 

--- a/tools/wiki/pyproject.toml
+++ b/tools/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memd-wiki"
-version = "1.1.0"
+version = "1.1.1"
 description = "Deterministic compiled markdown wiki over memd project state."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v1.1.1

Cuts a release so the warm-worker OOM fix (#8) reaches the prebuilt-first `make install` path. Without a tagged release, `make install` would refetch v1.1.0 and silently regress.

### Version bump
- `Cargo.toml` `[workspace.package].version` → `1.1.1` (canonical)
- `Cargo.lock`, `tools/wiki/pyproject.toml`, README + `docs/index.md` version badges
- `CHANGELOG.md` → `## [1.1.1]` entry

### What's in 1.1.1
The warm-worker memory fix from #8:
- Resident-worker **cap** (`MEMD_WARM_MAX_WORKERS`, default 16, cannot be disabled).
- **Idle-independent orphan eviction** (a replaced worker exits within ~60 s even when the idle reaper is off).
- **Ephemeral-data-dir guard** — auto-warm skipped for `pytest-of-` dirs (`MEMD_WARM_ALLOW_EPHEMERAL=1` to opt back in).

### On merge
`auto-release.yml` tags `v1.1.1` (PAT) → `release.yml` builds the 4-platform binaries + GitHub Release, and `publish-crate.yml` publishes to crates.io. Version-consistency check passes locally (all sources agree on 1.1.1).
