### PR TITLE
chore(release): v1.2.1 — retrieval robustness + perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-30
+
+Retrieval robustness and performance improvements.
+
+### Fixed
+
+- **Lexical query parsing**: BM25 search falls back to an alphanumeric-only query
+  when both strict and lenient Tantivy parsing fail (e.g. queries with brackets
+  or other special characters) instead of erroring — fewer failed lexical
+  searches and better recall on messy queries.
+- **Batch-add deduplication**: `memory.add_batch` now deduplicates exact-content
+  chunks both against the store and within the same batch before a single bulk
+  insert, so batch writes no longer create duplicate chunks.
+
+### Changed
+
+- **Skip the dense path when disabled**: hybrid search skips dense indexing and
+  dense search entirely when `dense_k == 0`, avoiding wasted embedding/search
+  work in sparse-only configurations.
+
 ## [1.2.0] - 2026-06-28
 
 Turns `memory.md` into a deterministic agent startup briefing and adds a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memd"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anndists",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "evals/harness"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.1-blue)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](Cargo.toml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-fmschulz.github.io%2Fmemd-blue)](https://fmschulz.github.io/memd/)

--- a/crates/memd/src/index/bm25.rs
+++ b/crates/memd/src/index/bm25.rs
@@ -36,6 +36,19 @@ fn escape_query_text(query: &str) -> String {
     escaped
 }
 
+fn plain_query_text(query: &str) -> String {
+    query
+        .chars()
+        .map(|ch| {
+            if ch.is_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
 fn parse_text_query(parser: &QueryParser, query: &str) -> Result<Box<dyn Query>> {
     match parser.parse_query(query) {
         Ok(parsed) => Ok(parsed),
@@ -48,6 +61,19 @@ fn parse_text_query(parser: &QueryParser, query: &str) -> Result<Box<dyn Query>>
             let (lenient_query, parse_errors) = parser.parse_query_lenient(&escaped_query);
             if parse_errors.is_empty() {
                 return Ok(lenient_query);
+            }
+
+            let plain_query = plain_query_text(query);
+            if !plain_query.trim().is_empty() {
+                if let Ok(parsed) = parser.parse_query(&plain_query) {
+                    return Ok(parsed);
+                }
+
+                let (plain_lenient_query, plain_parse_errors) =
+                    parser.parse_query_lenient(&plain_query);
+                if plain_parse_errors.is_empty() {
+                    return Ok(plain_lenient_query);
+                }
             }
 
             Err(MemdError::ValidationError(format!(
@@ -687,6 +713,40 @@ mod tests {
 
         let results = index.search(&tenant, "\"identity verification", 10);
         assert!(results.is_ok(), "unbalanced quote query should not error");
+    }
+
+    #[test]
+    fn test_benchmark_choice_query_with_brackets_does_not_error() {
+        let index = Bm25Index::new().unwrap();
+        let tenant = create_test_tenant();
+        let chunk_id = ChunkId::new();
+        index
+            .insert(
+                &tenant,
+                &chunk_id,
+                &[
+                    "Debbie sat with Stuart and Brent Tarleton on the porch of Tara.".to_string(),
+                    "Debbie gazed out the window, eager to see her friend arrive.".to_string(),
+                ],
+            )
+            .unwrap();
+
+        let query = "Search Archival Memory, complete the task below:\n\
+These are the events that have already occurred:\n\
+1. Debbie sat with Stuart and Brent Tarleton on the porch of Tara.\n\n\
+Below is a list of possible subsequent events:\n\
+['Debbie gazed out the window, eager to see her friend arrive.', \
+\"Debbie leaned against the fence, excitedly watching for her neighbor's dog.\"]";
+
+        let results = index.search(&tenant, query, 10);
+        assert!(
+            results.is_ok(),
+            "benchmark multiple-choice query should not error"
+        );
+        assert!(
+            !results.unwrap().is_empty(),
+            "plain-token fallback should still retrieve matches"
+        );
     }
 
     /// Regression test for the "Index already exists" silent-failure bug:

--- a/crates/memd/src/ops/mod.rs
+++ b/crates/memd/src/ops/mod.rs
@@ -6710,11 +6710,17 @@ pub async fn handle_memory_add_batch<S: Store>(
         .map(|(_, _, _, admission, _, _)| admission.outcome.reason.clone())
         .collect::<Vec<_>>();
 
-    let mut dedupe_decisions = Vec::with_capacity(prepared.len());
-    let mut deduped_existing_ids = Vec::with_capacity(prepared.len());
+    let prepared_len = prepared.len();
+    let mut dedupe_decisions = Vec::with_capacity(prepared_len);
+    let mut deduped_existing_ids = Vec::with_capacity(prepared_len);
     let mut any_default_deduped = false;
 
-    let chunk_ids = if let Some(ps) = store.as_persistent() {
+    let chunk_ids = if any_lifecycle {
+        let ps = store.as_persistent().ok_or_else(|| {
+            McpError::ToolError(
+                "memory.add_batch with temporal fields requires a persistent store".into(),
+            )
+        })?;
         let mut ids = Vec::with_capacity(prepared.len());
         for (chunk, delta, has_lifecycle, _, caller_tags, caller_requested_lifecycle) in prepared {
             if !caller_requested_lifecycle {
@@ -6745,25 +6751,99 @@ pub async fn handle_memory_add_batch<S: Store>(
             deduped_existing_ids.push(None);
         }
         ids
-    } else if any_lifecycle {
-        let ps = store.as_persistent().ok_or_else(|| {
-            McpError::ToolError(
-                "memory.add_batch with temporal fields requires a persistent store".into(),
-            )
-        })?;
-        // Per-chunk through add_chunk_with_lifecycle so the per-row
-        // overlay is applied. Failures still leave earlier rows
-        // committed — same contract as the bulk add_batch fast path.
-        let mut ids = Vec::with_capacity(prepared.len());
-        for (chunk, delta, _, _, _, _) in prepared {
-            let id = ps
-                .add_chunk_with_lifecycle(chunk, delta)
-                .await
-                .map_err(|e| McpError::ToolError(e.to_string()))?;
-            ids.push(id);
+    } else if store.as_persistent().is_some() {
+        dedupe_decisions = vec!["inserted".to_string(); prepared_len];
+        deduped_existing_ids = vec![None; prepared_len];
+
+        let mut ids_by_position: Vec<Option<ChunkId>> = vec![None; prepared_len];
+        let mut pending_insert_positions = Vec::new();
+        let mut pending_insert_chunks = Vec::new();
+        let mut pending_for_dedupe: Vec<(usize, MemoryChunk)> = Vec::new();
+        let mut pending_aliases: Vec<(usize, usize)> = Vec::new();
+
+        for (position, (chunk, _, _, _, caller_tags, _)) in prepared.into_iter().enumerate() {
+            if let Some(existing_id) =
+                find_default_content_duplicate(store, &chunk, &caller_tags).await?
+            {
+                let existing_id_string = existing_id.to_string();
+                ids_by_position[position] = Some(existing_id);
+                dedupe_decisions[position] = "reused_existing_exact_content".to_string();
+                deduped_existing_ids[position] = Some(existing_id_string);
+                any_default_deduped = true;
+                continue;
+            }
+
+            let mut pending_duplicate_position = None;
+            if !default_content_dedupe_exempt(&chunk, &caller_tags) {
+                for (prior_position, prior_chunk) in &pending_for_dedupe {
+                    if prior_chunk.text == chunk.text
+                        && prior_chunk.chunk_type == chunk.chunk_type
+                        && prior_chunk.project_id == chunk.project_id
+                        && (chunk.source == Source::empty() || chunk.source == prior_chunk.source)
+                        && caller_tags_already_preserved(prior_chunk, &caller_tags)
+                    {
+                        pending_duplicate_position = Some(*prior_position);
+                        break;
+                    }
+                }
+            }
+
+            if let Some(prior_position) = pending_duplicate_position {
+                pending_aliases.push((position, prior_position));
+                dedupe_decisions[position] = "reused_existing_exact_content".to_string();
+                any_default_deduped = true;
+                continue;
+            }
+
+            pending_insert_positions.push(position);
+            pending_for_dedupe.push((position, chunk.clone()));
+            pending_insert_chunks.push(chunk);
         }
-        ids
+
+        let inserted_ids = store
+            .add_batch(pending_insert_chunks)
+            .await
+            .map_err(|e| McpError::ToolError(e.to_string()))?;
+        if inserted_ids.len() != pending_insert_positions.len() {
+            return Err(McpError::ToolError(format!(
+                "memory.add_batch inserted {} chunks but expected {}",
+                inserted_ids.len(),
+                pending_insert_positions.len()
+            )));
+        }
+        for (position, id) in pending_insert_positions
+            .into_iter()
+            .zip(inserted_ids.into_iter())
+        {
+            ids_by_position[position] = Some(id);
+        }
+        for (position, prior_position) in pending_aliases {
+            let id = ids_by_position
+                .get(prior_position)
+                .and_then(|id| id.clone())
+                .ok_or_else(|| {
+                    McpError::ToolError(
+                        "memory.add_batch missing inserted id for within-batch duplicate".into(),
+                    )
+                })?;
+            deduped_existing_ids[position] = Some(id.to_string());
+            ids_by_position[position] = Some(id);
+        }
+
+        ids_by_position
+            .into_iter()
+            .enumerate()
+            .map(|(position, maybe_id)| {
+                maybe_id.ok_or_else(|| {
+                    McpError::ToolError(format!(
+                        "memory.add_batch did not produce chunk id for position {position}"
+                    ))
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, McpError>>()?
     } else {
+        dedupe_decisions = vec!["inserted".to_string(); prepared_len];
+        deduped_existing_ids = vec![None; prepared_len];
         // No lifecycle overlay anywhere → bulk path. The chunks already
         // carry the per-row ingestion_mode label (set in the pre-pass);
         // store.add_batch threads that through to ChunkMetadata.

--- a/crates/memd/src/store/hybrid.rs
+++ b/crates/memd/src/store/hybrid.rs
@@ -331,7 +331,9 @@ impl HybridSearcher {
             return Ok(());
         }
 
-        self.dense.index_batch(tenant_id, chunks).await?;
+        if self.config.dense_k > 0 {
+            self.dense.index_batch(tenant_id, chunks).await?;
+        }
 
         if self.config.enable_sparse {
             if let Some(ref sparse) = self.sparse {
@@ -598,12 +600,16 @@ impl HybridSearcher {
         let total_start = Instant::now();
         let mut timing = HybridTiming::default();
 
-        // Step 1: Dense search
         let dense_start = Instant::now();
-        let (dense_results, _embed_time, _search_time) = self
-            .dense
-            .search_with_timing(tenant_id, query, self.config.dense_k)
-            .await?;
+        let dense_results = if self.config.dense_k > 0 {
+            let (dense_results, _embed_time, _search_time) = self
+                .dense
+                .search_with_timing(tenant_id, query, self.config.dense_k)
+                .await?;
+            dense_results
+        } else {
+            Vec::new()
+        };
         timing.dense_time = dense_start.elapsed();
 
         // Step 2: Sparse search (if enabled)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
+[![Version](https://img.shields.io/badge/version-1.2.1-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](https://github.com/fmschulz/memd/blob/main/Cargo.toml){ .md-button }
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/fmschulz/memd/blob/main/LICENSE){ .md-button }
 

--- a/tools/wiki/pyproject.toml
+++ b/tools/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memd-wiki"
-version = "1.2.0"
+version = "1.2.1"
 description = "Deterministic compiled markdown wiki over memd project state."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v1.2.1 — retrieval robustness + performance

Consolidates three improvements that were sitting as uncommitted local WIP and were confirmed absent from `main` and the 1.2.0 release. Built on top of 1.2.0.

### Changes
- **`index/bm25.rs`** — lexical query-parse fallback: when strict *and* lenient Tantivy parsing both fail (e.g. queries with brackets/punctuation), retry with an alphanumeric-only query instead of erroring. Fewer failed lexical searches → better recall. Includes a regression test.
- **`ops/mod.rs`** — `memory.add_batch` now deduplicates exact-content chunks both against the store and within the same batch before a single bulk insert (was insert-then-per-row), so batch writes don't create duplicates.
- **`store/hybrid.rs`** — skip dense indexing and dense search entirely when `dense_k == 0`, avoiding wasted embedding/search work in sparse-only mode.

### Release mechanics
Version bumped 1.2.0 → 1.2.1 across Cargo.toml, Cargo.lock, pyproject, README + docs badges, CHANGELOG. Version-consistency passes locally; bm25 + hybrid unit tests green. On merge, `auto-release.yml` tags `v1.2.1` → `release.yml` (4-platform binaries + GitHub Release) + `publish-crate.yml` (crates.io).
