### PR TITLE
feat(embeddings): bge-base embedder + dense-only default (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-11
+
+### Added
+
+- **bge-base-en-v1.5 embedder** (`--embedding-model bge-base`): a 768-d Candle
+  BERT retriever (CLS pooling, query-only instruction prefix) selectable
+  alongside the default `all-minilm`. Assets are fetched on first use from a
+  pinned Hugging Face revision and verified by sha256, matching the existing
+  MiniLM download contract.
+- **Model-conditional default search variant**: when `bge-base` is selected and
+  `--search-variant` is not given, the retrieval default becomes `dense-only`
+  (hybrid fusion off). `all-minilm` and other models keep the `hybrid-feature`
+  default, and an explicit `--search-variant` always takes precedence.
+
+### Changed
+
+- **Warm workers report their embedding model and search variant in the ping
+  identity.** A resident worker serving a different model/variant than the
+  client requests is now shut down and respawned (the same path as a
+  version/protocol skew), instead of silently answering with the wrong
+  embedder.
+- **Switching `--embedding-model` on an existing store no longer wipes the
+  dense index.** A persisted index built at a different vector dimension
+  (e.g. bge-base 768-d vs all-minilm 384-d) is incompatible with the active
+  model; memd now fails with a clear error naming both dimensions instead of
+  deleting the embedding cache and leaving an empty index. Set
+  `MEMD_BACKFILL_HNSW_ON_STARTUP=1` to intentionally discard the dense index
+  and re-embed from segments under the new model. Same-dimension cache
+  corruption still deletes and rebuilds as before.
+- `CandleEmbedder::with_config` applies the model's required pooling strategy
+  (mean for MiniLM, CLS for bge-base), overriding any pooling carried on the
+  passed `EmbeddingConfig` — pooling is a property of the model's training
+  recipe, not a caller choice.
+
 ## [1.3.1] - 2026-07-06
 
 Fixes a 1.3.0 regression in warm-worker write acknowledgements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memd"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anndists",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "evals/harness"]
 resolver = "2"
 
 [workspace.package]
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.3.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](Cargo.toml)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-fmschulz.github.io%2Fmemd-blue)](https://fmschulz.github.io/memd/)

--- a/crates/memd/src/cli/args.rs
+++ b/crates/memd/src/cli/args.rs
@@ -616,6 +616,14 @@ pub enum CliCommand {
         /// Unix socket path to listen on.
         #[arg(long)]
         socket: PathBuf,
+        /// Embedding-model identity this worker serves, injected by the parent
+        /// before dispatch (not parsed from argv). Reported in the ping
+        /// identity so a client requesting a different model respawns it.
+        #[arg(skip)]
+        embedding_model: Option<String>,
+        /// Search-variant identity this worker serves (injected, see above).
+        #[arg(skip)]
+        search_variant: Option<String>,
     },
 
     /// Get a chunk by ID

--- a/crates/memd/src/cli/mod.rs
+++ b/crates/memd/src/cli/mod.rs
@@ -621,8 +621,19 @@ pub async fn run_cli<S: Store>(
             ));
         }
 
-        CliCommand::WarmWorker { socket } => {
-            run_warm_worker(store, tenant_manager, &socket).await?;
+        CliCommand::WarmWorker {
+            socket,
+            embedding_model,
+            search_variant,
+        } => {
+            run_warm_worker(
+                store,
+                tenant_manager,
+                &socket,
+                embedding_model.as_deref(),
+                search_variant.as_deref(),
+            )
+            .await?;
         }
 
         CliCommand::Maintenance {

--- a/crates/memd/src/cli/warm.rs
+++ b/crates/memd/src/cli/warm.rs
@@ -1036,7 +1036,10 @@ async fn shutdown_existing_warm_worker_best_effort(config: &WarmProcessConfig) {
 }
 
 fn warm_worker_needs_replacement(error: &MemdError) -> bool {
-    matches!(error, MemdError::IncompatibleWarmWorker { .. })
+    matches!(
+        error,
+        MemdError::IncompatibleWarmWorker { .. } | MemdError::WarmWorkerConfigMismatch { .. }
+    )
 }
 
 async fn replace_incompatible_warm_worker(config: &WarmProcessConfig) -> Result<Value> {
@@ -1232,7 +1235,32 @@ async fn warm_ping(config: &WarmProcessConfig) -> Result<Value> {
     }
     let result = response.result.unwrap_or(Value::Null);
     validate_warm_worker_identity(&result)?;
+    validate_warm_worker_config(&result, config)?;
     Ok(result)
+}
+
+/// Reject a resident worker whose embedding model or search variant differs
+/// from what this CLI requested, so `ensure_warm_worker` respawns it. Runs
+/// only after the version/protocol check, so a same-version worker is
+/// guaranteed to report these fields.
+fn validate_warm_worker_config(result: &Value, config: &WarmProcessConfig) -> Result<()> {
+    let worker_model = result
+        .get("embedding_model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let worker_variant = result
+        .get("search_variant")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if worker_model != config.embedding_model || worker_variant != config.search_variant {
+        return Err(MemdError::WarmWorkerConfigMismatch {
+            worker_model: worker_model.to_string(),
+            worker_variant: worker_variant.to_string(),
+            cli_model: config.embedding_model.clone(),
+            cli_variant: config.search_variant.clone(),
+        });
+    }
+    Ok(())
 }
 
 /// Diagnostic ping for `memd doctor`: returns the worker's identity
@@ -1251,12 +1279,19 @@ pub(super) async fn warm_ping_identity(data_dir: &Path) -> Result<Value> {
     Ok(response.result.unwrap_or(Value::Null))
 }
 
-fn warm_worker_identity(socket: &Path, ryw_probe_stats: Option<RywProbeStats>) -> Value {
+fn warm_worker_identity(
+    socket: &Path,
+    ryw_probe_stats: Option<RywProbeStats>,
+    embedding_model: &str,
+    search_variant: &str,
+) -> Value {
     let mut identity = json!({
         "pid": std::process::id(),
         "socket": socket,
         "memd_version": env!("CARGO_PKG_VERSION"),
         "warm_wire_protocol": WARM_WIRE_PROTOCOL,
+        "embedding_model": embedding_model,
+        "search_variant": search_variant,
     });
     if let Some(stats) = ryw_probe_stats {
         identity["ryw_probe"] = json!({
@@ -1505,8 +1540,15 @@ pub(super) async fn run_warm_worker<S: Store>(
     store: &S,
     tenant_manager: Option<&TenantManager>,
     socket: &Path,
+    embedding_model: Option<&str>,
+    search_variant: Option<&str>,
 ) -> Result<()> {
     use futures_util::stream::{FuturesUnordered, StreamExt};
+
+    // Identity this worker advertises in its ping handshake. Falls back to the
+    // documented defaults if the parent did not stamp them (test paths only).
+    let embedding_model = embedding_model.unwrap_or("all-minilm").to_string();
+    let search_variant = search_variant.unwrap_or("hybrid-feature").to_string();
     use std::os::unix::fs::PermissionsExt;
     use tokio::net::UnixListener;
     use tokio::sync::Semaphore;
@@ -1575,6 +1617,8 @@ pub(super) async fn run_warm_worker<S: Store>(
                             socket,
                             &semaphore,
                             stream,
+                            &embedding_model,
+                            &search_variant,
                         )));
                     }
                     Err(error) => {
@@ -1622,12 +1666,15 @@ pub(super) async fn run_warm_worker<S: Store>(
 }
 
 #[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
 async fn handle_warm_connection<S: Store>(
     store: &S,
     tenant_manager: Option<&TenantManager>,
     socket: &Path,
     semaphore: &tokio::sync::Semaphore,
     mut stream: tokio::net::UnixStream,
+    embedding_model: &str,
+    search_variant: &str,
 ) -> bool {
     use tokio::io::AsyncReadExt;
 
@@ -1639,12 +1686,20 @@ async fn handle_warm_connection<S: Store>(
 
     let mut shutdown = false;
     let response = match serde_json::from_slice::<WarmWireRequest>(&bytes) {
-        Ok(WarmWireRequest::Ping) => {
-            WarmWireResponse::ok_result(warm_worker_identity(socket, store.ryw_probe_stats()))
-        }
+        Ok(WarmWireRequest::Ping) => WarmWireResponse::ok_result(warm_worker_identity(
+            socket,
+            store.ryw_probe_stats(),
+            embedding_model,
+            search_variant,
+        )),
         Ok(WarmWireRequest::Shutdown) => {
             shutdown = true;
-            WarmWireResponse::ok_result(warm_worker_identity(socket, store.ryw_probe_stats()))
+            WarmWireResponse::ok_result(warm_worker_identity(
+                socket,
+                store.ryw_probe_stats(),
+                embedding_model,
+                search_variant,
+            ))
         }
         Ok(WarmWireRequest::Command { command }) => {
             let permit = match semaphore.acquire().await {
@@ -1748,7 +1803,12 @@ mod tests {
             stream.read_to_end(&mut bytes).await.unwrap();
             match serde_json::from_slice::<WarmWireRequest>(&bytes).unwrap() {
                 WarmWireRequest::Ping => {
-                    let response = WarmWireResponse::ok_result(warm_worker_identity(&socket, None));
+                    let response = WarmWireResponse::ok_result(warm_worker_identity(
+                        &socket,
+                        None,
+                        "all-minilm",
+                        "hybrid-feature",
+                    ));
                     assert!(write_warm_response(&mut stream, response).await);
                 }
                 WarmWireRequest::Command { .. } => {
@@ -1776,7 +1836,12 @@ mod tests {
             stream.read_to_end(&mut bytes).await.unwrap();
             match serde_json::from_slice::<WarmWireRequest>(&bytes).unwrap() {
                 WarmWireRequest::Ping => {
-                    let response = WarmWireResponse::ok_result(warm_worker_identity(&socket, None));
+                    let response = WarmWireResponse::ok_result(warm_worker_identity(
+                        &socket,
+                        None,
+                        "all-minilm",
+                        "hybrid-feature",
+                    ));
                     assert!(write_warm_response(&mut stream, response).await);
                 }
                 WarmWireRequest::Command { .. } => {
@@ -2086,7 +2151,12 @@ mod tests {
 
     #[test]
     fn warm_worker_identity_validation_accepts_current_payload() {
-        let payload = warm_worker_identity(Path::new("/tmp/memd.sock"), None);
+        let payload = warm_worker_identity(
+            Path::new("/tmp/memd.sock"),
+            None,
+            "all-minilm",
+            "hybrid-feature",
+        );
 
         validate_warm_worker_identity(&payload).unwrap();
     }
@@ -2101,6 +2171,8 @@ mod tests {
                 repairs: 1,
                 repair_in_progress: false,
             }),
+            "all-minilm",
+            "hybrid-feature",
         );
 
         assert_eq!(
@@ -2139,6 +2211,31 @@ mod tests {
                 worker_protocol,
                 ..
             } if worker_version == "0.0.1" && worker_protocol == "1"
+        ));
+        assert!(warm_worker_needs_replacement(&err));
+    }
+
+    #[test]
+    fn warm_worker_config_mismatch_is_detected_and_needs_replacement() {
+        // test_warm_config requests model=all-minilm, variant=hybrid-feature.
+        let config = test_warm_config(PathBuf::from("/tmp/warm-cfg-test"));
+
+        // A worker serving the same model/variant validates cleanly.
+        let matching = warm_worker_identity(
+            Path::new("/tmp/memd.sock"),
+            None,
+            "all-minilm",
+            "hybrid-feature",
+        );
+        validate_warm_worker_config(&matching, &config).unwrap();
+
+        // A bge/dense-only worker answering an all-minilm request is a
+        // respawn-triggering mismatch.
+        let bge = warm_worker_identity(Path::new("/tmp/memd.sock"), None, "bge-base", "dense-only");
+        let err = validate_warm_worker_config(&bge, &config).unwrap_err();
+        assert!(matches!(
+            &err,
+            MemdError::WarmWorkerConfigMismatch { worker_model, .. } if worker_model == "bge-base"
         ));
         assert!(warm_worker_needs_replacement(&err));
     }

--- a/crates/memd/src/embeddings/candle_embedder.rs
+++ b/crates/memd/src/embeddings/candle_embedder.rs
@@ -13,12 +13,10 @@ use parking_lot::Mutex;
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 use tokio::sync::Semaphore;
 
-use crate::embeddings::download::get_candle_bert_paths;
+use crate::embeddings::download::{get_candle_model_paths, CandleModel};
 use crate::embeddings::traits::{Embedder, EmbeddingConfig, EmbeddingResult, PoolingStrategy};
 use crate::error::{MemdError, Result};
 
-const DEFAULT_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
-const DEFAULT_DIMENSION: usize = 384;
 const DEFAULT_MAX_LENGTH: usize = 512;
 const MODEL_POOL_SIZE: usize = 4; // 4 models for parallel inference
                                   // MAX_CONCURRENT derived from MODEL_POOL_SIZE to avoid duplication
@@ -98,19 +96,32 @@ pub struct CandleEmbedder {
     dimension: usize,
     /// Embedding configuration
     config: EmbeddingConfig,
+    /// Retrieval query prefix (model-specific; applied to queries only)
+    query_prefix: Option<&'static str>,
 }
 
 impl CandleEmbedder {
-    /// Create a new CandleEmbedder with default model (all-MiniLM-L6-v2)
+    /// Create a new CandleEmbedder with the default model (all-MiniLM-L6-v2).
     pub fn new() -> Result<Self> {
         Self::with_config(EmbeddingConfig::default())
     }
 
-    /// Create with custom configuration
+    /// Create with custom configuration and the default model
+    /// (all-MiniLM-L6-v2). Use `with_config_and_model` to select a model.
     pub fn with_config(config: EmbeddingConfig) -> Result<Self> {
+        Self::with_config_and_model(config, CandleModel::default())
+    }
+
+    /// Create with custom configuration and an explicit Candle model.
+    ///
+    /// Pooling and the query prefix are properties of the model's training
+    /// recipe, so they override whatever the caller's config carried.
+    pub fn with_config_and_model(mut config: EmbeddingConfig, model: CandleModel) -> Result<Self> {
+        config.pooling = model.pooling_strategy();
+
         tracing::info!(
-            model = DEFAULT_MODEL,
-            dimension = DEFAULT_DIMENSION,
+            model = model.hf_id(),
+            pooling = ?config.pooling,
             "initializing Candle embedder"
         );
 
@@ -176,7 +187,7 @@ impl CandleEmbedder {
         // (`~/.cache/huggingface/hub` or `$HF_HOME/hub`). Hosts with a
         // populated hf-hub cache but no network will re-download on first
         // upgrade — see CHANGELOG.
-        let (config_path, tokenizer_path, weights_path) = get_candle_bert_paths()?;
+        let (config_path, tokenizer_path, weights_path) = get_candle_model_paths(model)?;
 
         // Load and validate model config
         let config_str = std::fs::read_to_string(&config_path)
@@ -258,6 +269,7 @@ impl CandleEmbedder {
             device,
             dimension,
             config,
+            query_prefix: model.query_prefix(),
         })
     }
 
@@ -388,7 +400,15 @@ impl CandleEmbedder {
 #[async_trait]
 impl Embedder for CandleEmbedder {
     async fn embed_query(&self, query: &str) -> Result<EmbeddingResult> {
-        self.embed_single(query).await
+        // Retrieval-tuned models (BGE) expect an instruction prefix on the
+        // query side only; documents are embedded verbatim by embed_texts.
+        match self.query_prefix {
+            Some(prefix) => {
+                let prefixed = format!("{prefix}{query}");
+                self.embed_single(&prefixed).await
+            }
+            None => self.embed_single(query).await,
+        }
     }
 
     async fn embed_texts(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {

--- a/crates/memd/src/embeddings/download.rs
+++ b/crates/memd/src/embeddings/download.rs
@@ -210,6 +210,70 @@ const MIN_CANDLE_BERT_CONFIG_SIZE: u64 = 100; // config.json is ~600 bytes
 const MIN_CANDLE_BERT_TOKENIZER_SIZE: u64 = 100_000; // tokenizer.json is ~470KB
 const MIN_CANDLE_BERT_WEIGHTS_SIZE: u64 = 80_000_000; // safetensors is ~90MB
 
+// Candle BERT (safetensors) files for BAAI/bge-base-en-v1.5 — a stronger
+// 768-d BERT retriever selectable via `--embedding-model bge-base`. Same
+// pinned-immutable-revision + sha256 contract as the MiniLM constants.
+const CANDLE_BGE_CONFIG_URL: &str =
+    "https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/config.json";
+const CANDLE_BGE_CONFIG_SHA256: &str =
+    "bc00af31a4a31b74040d73370aa83b62da34c90b75eb77bfa7db039d90abd591";
+const CANDLE_BGE_CONFIG_FILENAME: &str = "bge-base-en-v1.5-config.json";
+const CANDLE_BGE_TOKENIZER_URL: &str =
+    "https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/tokenizer.json";
+const CANDLE_BGE_TOKENIZER_SHA256: &str =
+    "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66";
+const CANDLE_BGE_TOKENIZER_FILENAME: &str = "bge-base-en-v1.5-tokenizer.json";
+const CANDLE_BGE_WEIGHTS_URL: &str =
+    "https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/a5beb1e3e68b9ab74eb54cfd186867f64f240e1a/model.safetensors";
+const CANDLE_BGE_WEIGHTS_SHA256: &str =
+    "c7c1988aae201f80cf91a5dbbd5866409503b89dcaba877ca6dba7dd0a5167d7";
+const CANDLE_BGE_WEIGHTS_FILENAME: &str = "bge-base-en-v1.5.safetensors";
+const MIN_CANDLE_BGE_CONFIG_SIZE: u64 = 100; // config.json is ~800 bytes
+const MIN_CANDLE_BGE_TOKENIZER_SIZE: u64 = 100_000; // tokenizer.json is ~700KB
+const MIN_CANDLE_BGE_WEIGHTS_SIZE: u64 = 400_000_000; // safetensors is ~438MB
+
+/// Which BERT-family model the Candle embedder loads.
+///
+/// Selected through the normal config surface (`--embedding-model bge-base`,
+/// which threads down to the store as `PersistentStoreConfig::candle_model`).
+/// Pooling and the retrieval query prefix are properties of the model, not
+/// user-configurable — mirroring how `EmbeddingModel` ties pooling to
+/// architecture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CandleModel {
+    /// sentence-transformers/all-MiniLM-L6-v2: 384-d, mean pooling
+    #[default]
+    MiniLm,
+    /// BAAI/bge-base-en-v1.5: 768-d, CLS pooling, query prefix at recall
+    BgeBase,
+}
+
+impl CandleModel {
+    /// Pooling strategy required by this model's training recipe.
+    pub fn pooling_strategy(&self) -> PoolingStrategy {
+        match self {
+            Self::MiniLm => PoolingStrategy::Mean,
+            Self::BgeBase => PoolingStrategy::Cls,
+        }
+    }
+
+    /// Retrieval query prefix, applied to queries only (never documents).
+    pub fn query_prefix(&self) -> Option<&'static str> {
+        match self {
+            Self::MiniLm => None,
+            Self::BgeBase => Some("Represent this sentence for searching relevant passages: "),
+        }
+    }
+
+    /// Human-readable model id for logs.
+    pub fn hf_id(&self) -> &'static str {
+        match self {
+            Self::MiniLm => "sentence-transformers/all-MiniLM-L6-v2",
+            Self::BgeBase => "BAAI/bge-base-en-v1.5",
+        }
+    }
+}
+
 /// Get the cache directory for memd models
 pub fn get_cache_dir() -> Result<PathBuf> {
     let cache_dir = dirs::cache_dir()
@@ -765,46 +829,78 @@ impl Drop for LockGuard {
 /// the `sentence-transformers/all-MiniLM-L6-v2` repo used by the Candle BERT
 /// embedder. Returns the local paths in (config, tokenizer, weights) order.
 pub fn get_candle_bert_paths() -> Result<(PathBuf, PathBuf, PathBuf)> {
+    get_candle_model_paths(CandleModel::MiniLm)
+}
+
+/// Get paths to the Candle model files for the selected BERT-family model.
+///
+/// Same download/verify contract as `get_candle_bert_paths`, parameterized
+/// over the model chosen via `--embedding-model`.
+pub fn get_candle_model_paths(model: CandleModel) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    struct Spec {
+        config: (&'static str, &'static str, &'static str, u64),
+        tokenizer: (&'static str, &'static str, &'static str, u64),
+        weights: (&'static str, &'static str, &'static str, u64),
+    }
+    let spec = match model {
+        CandleModel::MiniLm => Spec {
+            config: (
+                CANDLE_BERT_CONFIG_URL,
+                CANDLE_BERT_CONFIG_FILENAME,
+                CANDLE_BERT_CONFIG_SHA256,
+                MIN_CANDLE_BERT_CONFIG_SIZE,
+            ),
+            tokenizer: (
+                CANDLE_BERT_TOKENIZER_URL,
+                CANDLE_BERT_TOKENIZER_FILENAME,
+                CANDLE_BERT_TOKENIZER_SHA256,
+                MIN_CANDLE_BERT_TOKENIZER_SIZE,
+            ),
+            weights: (
+                CANDLE_BERT_WEIGHTS_URL,
+                CANDLE_BERT_WEIGHTS_FILENAME,
+                CANDLE_BERT_WEIGHTS_SHA256,
+                MIN_CANDLE_BERT_WEIGHTS_SIZE,
+            ),
+        },
+        CandleModel::BgeBase => Spec {
+            config: (
+                CANDLE_BGE_CONFIG_URL,
+                CANDLE_BGE_CONFIG_FILENAME,
+                CANDLE_BGE_CONFIG_SHA256,
+                MIN_CANDLE_BGE_CONFIG_SIZE,
+            ),
+            tokenizer: (
+                CANDLE_BGE_TOKENIZER_URL,
+                CANDLE_BGE_TOKENIZER_FILENAME,
+                CANDLE_BGE_TOKENIZER_SHA256,
+                MIN_CANDLE_BGE_TOKENIZER_SIZE,
+            ),
+            weights: (
+                CANDLE_BGE_WEIGHTS_URL,
+                CANDLE_BGE_WEIGHTS_FILENAME,
+                CANDLE_BGE_WEIGHTS_SHA256,
+                MIN_CANDLE_BGE_WEIGHTS_SIZE,
+            ),
+        },
+    };
+
     let cache_dir = get_cache_dir()?;
     std::fs::create_dir_all(&cache_dir)?;
 
-    let config_path = cache_dir.join(CANDLE_BERT_CONFIG_FILENAME);
-    if !config_path.exists() {
-        download_file(
-            CANDLE_BERT_CONFIG_URL,
-            &config_path,
-            "BERT config",
-            Some(CANDLE_BERT_CONFIG_SHA256),
-        )?;
-    }
-    verify_file_size(&config_path, MIN_CANDLE_BERT_CONFIG_SIZE, "BERT config")?;
+    let fetch =
+        |(url, filename, sha, min_size): (&str, &str, &str, u64), kind: &str| -> Result<PathBuf> {
+            let path = cache_dir.join(filename);
+            if !path.exists() {
+                download_file(url, &path, kind, Some(sha))?;
+            }
+            verify_file_size(&path, min_size, kind)?;
+            Ok(path)
+        };
 
-    let tokenizer_path = cache_dir.join(CANDLE_BERT_TOKENIZER_FILENAME);
-    if !tokenizer_path.exists() {
-        download_file(
-            CANDLE_BERT_TOKENIZER_URL,
-            &tokenizer_path,
-            "BERT tokenizer",
-            Some(CANDLE_BERT_TOKENIZER_SHA256),
-        )?;
-    }
-    verify_file_size(
-        &tokenizer_path,
-        MIN_CANDLE_BERT_TOKENIZER_SIZE,
-        "BERT tokenizer",
-    )?;
-
-    let weights_path = cache_dir.join(CANDLE_BERT_WEIGHTS_FILENAME);
-    if !weights_path.exists() {
-        download_file(
-            CANDLE_BERT_WEIGHTS_URL,
-            &weights_path,
-            "BERT weights",
-            Some(CANDLE_BERT_WEIGHTS_SHA256),
-        )?;
-    }
-    verify_file_size(&weights_path, MIN_CANDLE_BERT_WEIGHTS_SIZE, "BERT weights")?;
-
+    let config_path = fetch(spec.config, "BERT config")?;
+    let tokenizer_path = fetch(spec.tokenizer, "BERT tokenizer")?;
+    let weights_path = fetch(spec.weights, "BERT weights")?;
     Ok((config_path, tokenizer_path, weights_path))
 }
 
@@ -944,6 +1040,9 @@ mod tests {
             CANDLE_BERT_CONFIG_URL,
             CANDLE_BERT_TOKENIZER_URL,
             CANDLE_BERT_WEIGHTS_URL,
+            CANDLE_BGE_CONFIG_URL,
+            CANDLE_BGE_TOKENIZER_URL,
+            CANDLE_BGE_WEIGHTS_URL,
             EmbeddingModel::AllMiniLmL6V2.model_url(),
             EmbeddingModel::AllMiniLmL6V2.tokenizer_url(),
             EmbeddingModel::Qwen3Embedding0_6B.model_url(),
@@ -966,10 +1065,32 @@ mod tests {
             CANDLE_BERT_CONFIG_SHA256,
             CANDLE_BERT_TOKENIZER_SHA256,
             CANDLE_BERT_WEIGHTS_SHA256,
+            CANDLE_BGE_CONFIG_SHA256,
+            CANDLE_BGE_TOKENIZER_SHA256,
+            CANDLE_BGE_WEIGHTS_SHA256,
         ];
         for hash in hashes {
             assert_sha256_constant(hash);
         }
+    }
+
+    #[test]
+    fn test_candle_model_selection_and_properties() {
+        // Default is MiniLM with mean pooling and no query prefix; BGE uses
+        // CLS pooling with the retrieval instruction prefix on queries only.
+        assert_eq!(CandleModel::default(), CandleModel::MiniLm);
+        assert_eq!(
+            CandleModel::MiniLm.pooling_strategy(),
+            PoolingStrategy::Mean
+        );
+        assert!(CandleModel::MiniLm.query_prefix().is_none());
+        assert_eq!(
+            CandleModel::BgeBase.pooling_strategy(),
+            PoolingStrategy::Cls
+        );
+        let prefix = CandleModel::BgeBase.query_prefix().unwrap();
+        assert!(prefix.starts_with("Represent this sentence"));
+        assert!(CandleModel::BgeBase.hf_id().contains("bge-base-en-v1.5"));
     }
 
     #[test]

--- a/crates/memd/src/embeddings/mod.rs
+++ b/crates/memd/src/embeddings/mod.rs
@@ -11,7 +11,7 @@ pub mod traits;
 // pub mod python_embedder;
 
 pub use candle_embedder::CandleEmbedder;
-pub use download::EmbeddingModel;
+pub use download::{CandleModel, EmbeddingModel};
 pub use mock::MockEmbedder;
 // pub use onnx::OnnxEmbedder;
 // pub use python_embedder::PythonEmbedder;

--- a/crates/memd/src/error.rs
+++ b/crates/memd/src/error.rs
@@ -47,6 +47,36 @@ pub enum MemdError {
         cli_protocol: String,
     },
 
+    /// Warm worker serves a different embedding model or search variant than
+    /// this CLI requested. Triggers the same shutdown+respawn as a version
+    /// skew so a resident MiniLM/hybrid worker never answers bge/dense-only
+    /// requests (and vice versa).
+    #[error(
+        "warm worker configuration mismatch: worker serves model {worker_model} / variant {worker_variant}; CLI requested model {cli_model} / variant {cli_variant}"
+    )]
+    WarmWorkerConfigMismatch {
+        worker_model: String,
+        worker_variant: String,
+        cli_model: String,
+        cli_variant: String,
+    },
+
+    /// The persisted dense index was built with a different embedding model
+    /// (vector dimension) than the one now active — i.e. `--embedding-model`
+    /// was changed on an existing store. Refused rather than silently wiping
+    /// the index (dense-only search has no sparse fallback).
+    #[error(
+        "dense index at {path} holds {store_dim}-d embeddings but the active embedding model produces {model_dim}-d vectors; this store was built with a different --embedding-model. Re-open with the original model, or set MEMD_BACKFILL_HNSW_ON_STARTUP=1 to discard the dense index and re-embed from segments."
+    )]
+    DenseIndexModelMismatch {
+        /// Path to the embedding cache that could not be reused.
+        path: std::path::PathBuf,
+        /// Vector dimension of the persisted index.
+        store_dim: usize,
+        /// Vector dimension the active embedding model produces.
+        model_dim: usize,
+    },
+
     /// Another process currently owns the persistent-store writer lock.
     #[error(
         "writer lock held by another process ({holder}) at {lock_path}; if a memd warm worker is running, route this write through it (--warm auto, the default) or stop it with `memd warm stop`; otherwise stop the other memd process or retry later (MEMD_WRITER_LOCK_TIMEOUT_MS)"

--- a/crates/memd/src/index/hnsw.rs
+++ b/crates/memd/src/index/hnsw.rs
@@ -52,6 +52,13 @@ pub struct HnswConfig {
     /// not an index property: never persisted.
     #[serde(skip)]
     pub search_lock_budget_ms: Option<u64>,
+    /// Operator opt-in (`MEMD_BACKFILL_HNSW_ON_STARTUP=1`) to re-embed from
+    /// segments. When set, a persisted cache whose dimension no longer matches
+    /// the active embedding model is discarded and rebuilt instead of erroring
+    /// — the intentional model-switch migration path. Runtime policy, never
+    /// persisted.
+    #[serde(skip)]
+    pub backfill_hnsw_on_startup: bool,
 }
 
 fn default_persist_graph_dump() -> bool {
@@ -68,6 +75,7 @@ impl Default for HnswConfig {
             dimension: 384,        // all-MiniLM-L6-v2 (TODO: 1024 for Qwen3 upgrade)
             persist_graph_dump: true,
             search_lock_budget_ms: None,
+            backfill_hnsw_on_startup: false,
         }
     }
 }
@@ -239,6 +247,12 @@ impl HnswIndex {
                     tracing::info!("Loaded persisted HNSW index from {:?}", path);
                     return Ok(index);
                 }
+                // A model/dimension mismatch is a hard error: the store was
+                // built with a different embedder. Falling through to an empty
+                // index here would let save_all() clobber the intact cache on
+                // shutdown (the round-1 data-loss). Propagate it; only genuine
+                // load failures degrade to an empty index.
+                Err(e @ MemdError::DenseIndexModelMismatch { .. }) => return Err(e),
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
@@ -660,14 +674,39 @@ impl HnswIndex {
         let embedding_cache = if cache_path.exists() {
             match EmbeddingCache::load_from(&cache_path) {
                 Ok(cache) => {
-                    // Validate consistency
-                    if let Err(e) = cache.validate_consistency(config.dimension, mapping.next_id) {
+                    if cache.dimension() != config.dimension {
+                        // Wrong model for this store: switching --embedding-model
+                        // changes the vector dimension. Deleting the cache here
+                        // would silently wipe the dense index (and dense-only
+                        // search has no sparse fallback), so refuse loudly —
+                        // unless the operator opted into re-embedding from
+                        // segments via MEMD_BACKFILL_HNSW_ON_STARTUP.
+                        if config.backfill_hnsw_on_startup && !read_only {
+                            tracing::warn!(
+                                store_dim = cache.dimension(),
+                                model_dim = config.dimension,
+                                "dense index dimension differs from the active model; \
+                                 backfill opt-in set — discarding cache and re-embedding from segments"
+                            );
+                            let _ = std::fs::remove_file(&cache_path);
+                            EmbeddingCache::new(config.dimension)
+                        } else {
+                            return Err(MemdError::DenseIndexModelMismatch {
+                                path: cache_path.clone(),
+                                store_dim: cache.dimension(),
+                                model_dim: config.dimension,
+                            });
+                        }
+                    } else if let Err(e) =
+                        cache.validate_consistency(config.dimension, mapping.next_id)
+                    {
+                        // Same-dimension corruption (count mismatch): genuine
+                        // corruption — delete and rebuild from segments.
                         tracing::warn!(
                             "Embedding cache validation failed: {}. Will need rebuild from segments.",
                             e
                         );
                         if !read_only {
-                            // Delete corrupted cache so the writer path can rebuild cleanly.
                             let _ = std::fs::remove_file(&cache_path);
                         }
                         EmbeddingCache::new(config.dimension)
@@ -1086,6 +1125,107 @@ mod tests {
             let mapping = index.mapping.read();
             assert!(mapping.chunk_to_id.contains_key(&chunk_id_str));
         }
+    }
+
+    #[test]
+    fn test_dimension_mismatch_errors_without_deleting_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index");
+
+        // Persist a 4-d index (simulating a store built with one model).
+        let config = HnswConfig {
+            max_elements: 100,
+            dimension: 4,
+            ..Default::default()
+        };
+        {
+            let index = HnswIndex::with_persistence(config.clone(), &path).unwrap();
+            let mut emb = vec![1.0, 0.0, 0.0, 0.0];
+            normalize(&mut emb);
+            index.insert(&ChunkId::new(), &emb).unwrap();
+            index.save().unwrap();
+        }
+        let cache_path = path.join("embeddings.bin");
+        assert!(cache_path.exists(), "cache should have been persisted");
+
+        // Re-open with a different dimension (wrong model): must hard-error and
+        // NOT delete the persisted cache.
+        let wrong = HnswConfig {
+            max_elements: 100,
+            dimension: 8,
+            ..Default::default()
+        };
+        // Note: HnswIndex is not Debug, so match rather than unwrap_err().
+        match HnswIndex::load(&path, wrong.clone()) {
+            Err(MemdError::DenseIndexModelMismatch {
+                store_dim,
+                model_dim,
+                ..
+            }) => {
+                assert_eq!(store_dim, 4);
+                assert_eq!(model_dim, 8);
+            }
+            Err(other) => panic!("expected DenseIndexModelMismatch, got {other:?}"),
+            Ok(_) => panic!("expected dimension mismatch to error, got Ok"),
+        }
+        assert!(
+            cache_path.exists(),
+            "dimension mismatch must not delete the persisted cache"
+        );
+
+        // With the backfill opt-in, the same mismatch discards and rebuilds
+        // instead of erroring (the intentional model-switch migration path).
+        let migrate = HnswConfig {
+            backfill_hnsw_on_startup: true,
+            ..wrong
+        };
+        let index = HnswIndex::load(&path, migrate).unwrap();
+        assert_eq!(index.config.dimension, 8);
+    }
+
+    #[test]
+    fn test_with_persistence_propagates_dimension_mismatch() {
+        // Production opens the dense index via with_persistence (not load()),
+        // whose error arm previously swallowed any failure into an empty index
+        // that save_all() would later clobber the real cache with. The
+        // model/dimension mismatch must propagate as a hard error here too.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index");
+        let config = HnswConfig {
+            max_elements: 100,
+            dimension: 4,
+            ..Default::default()
+        };
+        {
+            let index = HnswIndex::with_persistence(config.clone(), &path).unwrap();
+            let mut emb = vec![1.0, 0.0, 0.0, 0.0];
+            normalize(&mut emb);
+            index.insert(&ChunkId::new(), &emb).unwrap();
+            index.save().unwrap();
+        }
+        let cache_path = path.join("embeddings.bin");
+
+        let wrong = HnswConfig {
+            max_elements: 100,
+            dimension: 8,
+            ..Default::default()
+        };
+        match HnswIndex::with_persistence(wrong, &path) {
+            Err(MemdError::DenseIndexModelMismatch {
+                store_dim,
+                model_dim,
+                ..
+            }) => {
+                assert_eq!(store_dim, 4);
+                assert_eq!(model_dim, 8);
+            }
+            Err(other) => panic!("expected DenseIndexModelMismatch, got {other:?}"),
+            Ok(_) => panic!("with_persistence swallowed the mismatch into an empty index"),
+        }
+        assert!(
+            cache_path.exists(),
+            "dimension mismatch must not delete the persisted cache"
+        );
     }
 
     #[test]

--- a/crates/memd/src/main.rs
+++ b/crates/memd/src/main.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use memd::cli::{
     run_cli, run_warm_admin, try_run_warm_client, CliCommand, StoreAccess, WarmProcessConfig,
 };
-use memd::embeddings::EmbeddingModel;
+use memd::embeddings::{CandleModel, EmbeddingModel};
 use memd::store::HybridConfig;
 use memd::{
     configure_operation_routing, init_logging, load_config, MemoryStore, PersistentStore,
@@ -15,12 +15,15 @@ use memd::{
 };
 
 /// Embedding model choice
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum ModelChoice {
     /// all-MiniLM-L6-v2: 384-dim, fast, good quality (default)
     AllMinilm,
     /// Qwen3-Embedding-0.6B: 1024-dim, slower, best quality (not yet supported in Candle)
     Qwen3,
+    /// bge-base-en-v1.5: 768-dim Candle BERT, stronger retrieval (CLS pooling,
+    /// dense-only by default)
+    BgeBase,
 }
 
 impl From<ModelChoice> for EmbeddingModel {
@@ -28,6 +31,20 @@ impl From<ModelChoice> for EmbeddingModel {
         match choice {
             ModelChoice::AllMinilm => EmbeddingModel::AllMiniLmL6V2,
             ModelChoice::Qwen3 => EmbeddingModel::Qwen3Embedding0_6B,
+            // EmbeddingModel is the vestigial ONNX-era selector and has no bge
+            // variant; the live Candle model is chosen via CandleModel below.
+            ModelChoice::BgeBase => EmbeddingModel::AllMiniLmL6V2,
+        }
+    }
+}
+
+impl From<ModelChoice> for CandleModel {
+    fn from(choice: ModelChoice) -> Self {
+        match choice {
+            // Qwen3 is not supported by the Candle BERT backend; it has always
+            // run MiniLM there, so preserve that behavior.
+            ModelChoice::AllMinilm | ModelChoice::Qwen3 => CandleModel::MiniLm,
+            ModelChoice::BgeBase => CandleModel::BgeBase,
         }
     }
 }
@@ -37,8 +54,25 @@ impl ModelChoice {
         match self {
             ModelChoice::AllMinilm => "all-minilm",
             ModelChoice::Qwen3 => "qwen3",
+            ModelChoice::BgeBase => "bge-base",
         }
     }
+}
+
+/// Resolve the default retrieval strategy for a model when `--search-variant`
+/// is not given explicitly. bge-base defaults to dense-only (hybrid fusion
+/// off); every other model keeps the hybrid-feature default.
+fn default_search_variant(model: ModelChoice) -> SearchVariant {
+    match model {
+        ModelChoice::BgeBase => SearchVariant::DenseOnly,
+        _ => SearchVariant::HybridFeature,
+    }
+}
+
+/// Resolve the effective retrieval strategy: an explicit `--search-variant`
+/// wins; otherwise fall back to the model-derived default.
+fn resolve_search_variant(explicit: Option<SearchVariant>, model: ModelChoice) -> SearchVariant {
+    explicit.unwrap_or_else(|| default_search_variant(model))
 }
 
 /// Retrieval strategy for persistent mode.
@@ -92,8 +126,11 @@ struct Args {
     embedding_model: ModelChoice,
 
     /// Retrieval strategy variant for persistent mode
-    #[arg(long, value_enum, default_value = "hybrid-feature")]
-    search_variant: SearchVariant,
+    ///
+    /// Defaults to dense-only for bge-base and hybrid-feature for other
+    /// models when not given explicitly.
+    #[arg(long, value_enum)]
+    search_variant: Option<SearchVariant>,
 
     /// CLI subcommand
     #[command(subcommand)]
@@ -155,11 +192,30 @@ async fn main() {
         std::process::exit(1);
     }
 
+    // Resolve the retrieval strategy once, here, so an unset --search-variant
+    // takes the model-derived default (dense-only for bge-base) and warm
+    // workers are spawned with the same concrete variant.
+    let search_variant = resolve_search_variant(args.search_variant, args.embedding_model);
+
+    // Stamp the worker's model/variant identity onto the (hidden) WarmWorker
+    // command so it reports them in the ping handshake; a client requesting a
+    // different model/variant then respawns it instead of being answered by
+    // the wrong embedder.
+    if let CliCommand::WarmWorker {
+        embedding_model,
+        search_variant: worker_variant,
+        ..
+    } = &mut cmd
+    {
+        *embedding_model = Some(args.embedding_model.cli_value().to_string());
+        *worker_variant = Some(search_variant.cli_value().to_string());
+    }
+
     let warm_config = WarmProcessConfig {
         data_dir: data_dir.clone(),
         config_path: args.config.clone(),
         embedding_model: args.embedding_model.cli_value().to_string(),
-        search_variant: args.search_variant.cli_value().to_string(),
+        search_variant: search_variant.cli_value().to_string(),
     };
 
     if let CliCommand::Warm { command } = &cmd {
@@ -223,9 +279,10 @@ async fn main() {
             data_dir: data_dir.clone(),
             read_only: cmd.store_access() == StoreAccess::ReadOnly,
             embedding_model: args.embedding_model.into(),
+            candle_model: args.embedding_model.into(),
             ..Default::default()
         };
-        apply_search_variant(args.search_variant, &mut store_config);
+        apply_search_variant(search_variant, &mut store_config);
         if matches!(&cmd, CliCommand::WarmWorker { .. }) {
             // A warm worker that cannot promptly become THE writer must exit
             // and let the client's ping find the winner / fall back. Long
@@ -282,5 +339,70 @@ fn apply_search_variant(search_variant: SearchVariant, config: &mut PersistentSt
             hybrid.reranker.mode = RerankerMode::Feature;
             config.hybrid_config = Some(hybrid);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_choice_maps_to_candle_model() {
+        // The Candle backend is the live embedder; bge-base selects it.
+        assert_eq!(
+            CandleModel::from(ModelChoice::AllMinilm),
+            CandleModel::MiniLm
+        );
+        assert_eq!(
+            CandleModel::from(ModelChoice::BgeBase),
+            CandleModel::BgeBase
+        );
+        // Qwen3 has no Candle backend and has always run MiniLM there.
+        assert_eq!(CandleModel::from(ModelChoice::Qwen3), CandleModel::MiniLm);
+    }
+
+    #[test]
+    fn bge_choice_has_cli_value_and_vestigial_onnx_mapping() {
+        assert_eq!(ModelChoice::BgeBase.cli_value(), "bge-base");
+        // EmbeddingModel is the vestigial ONNX selector; bge maps onto the
+        // MiniLM id there because the live model flows via CandleModel.
+        assert_eq!(
+            EmbeddingModel::from(ModelChoice::BgeBase),
+            EmbeddingModel::AllMiniLmL6V2
+        );
+    }
+
+    #[test]
+    fn default_search_variant_is_dense_only_for_bge_only() {
+        assert!(matches!(
+            default_search_variant(ModelChoice::BgeBase),
+            SearchVariant::DenseOnly
+        ));
+        assert!(matches!(
+            default_search_variant(ModelChoice::AllMinilm),
+            SearchVariant::HybridFeature
+        ));
+        assert!(matches!(
+            default_search_variant(ModelChoice::Qwen3),
+            SearchVariant::HybridFeature
+        ));
+    }
+
+    #[test]
+    fn explicit_search_variant_overrides_bge_default() {
+        // An explicit flag wins even against bge's dense-only default.
+        assert!(matches!(
+            resolve_search_variant(Some(SearchVariant::HybridFeature), ModelChoice::BgeBase),
+            SearchVariant::HybridFeature
+        ));
+        // An unset flag falls back to the model-derived default.
+        assert!(matches!(
+            resolve_search_variant(None, ModelChoice::BgeBase),
+            SearchVariant::DenseOnly
+        ));
+        assert!(matches!(
+            resolve_search_variant(None, ModelChoice::AllMinilm),
+            SearchVariant::HybridFeature
+        ));
     }
 }

--- a/crates/memd/src/store/dense.rs
+++ b/crates/memd/src/store/dense.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use parking_lot::RwLock;
 
 use crate::compaction::hnsw_rebuild::{HnswRebuilder, RebuildResult};
-use crate::embeddings::{CandleEmbedder, Embedder, EmbeddingConfig};
+use crate::embeddings::{CandleEmbedder, CandleModel, Embedder, EmbeddingConfig};
 use crate::error::{MemdError, Result};
 use crate::index::{HnswConfig, HnswIndex};
 use crate::metrics::IndexStats;
@@ -32,9 +32,8 @@ pub struct DenseSearchConfig {
     pub hnsw: HnswConfig,
     /// Whether to persist index
     pub persist: bool,
-    // Temporarily removed during Candle migration
-    // /// Embedding model to use
-    // pub model: EmbeddingModel,
+    /// Candle embedder model to load (selected via `--embedding-model`).
+    pub model: CandleModel,
 }
 
 impl Default for DenseSearchConfig {
@@ -42,7 +41,7 @@ impl Default for DenseSearchConfig {
         Self {
             hnsw: HnswConfig::default(),
             persist: true,
-            // model: EmbeddingModel::default(),
+            model: CandleModel::default(),
         }
     }
 }
@@ -74,7 +73,10 @@ impl DenseSearcher {
     pub fn new(config: DenseSearchConfig) -> Result<Self> {
         let mut embedding_config = EmbeddingConfig::default();
         embedding_config.batch_size = embedding_batch_size();
-        let embedder = Arc::new(CandleEmbedder::with_config(embedding_config)?);
+        let embedder = Arc::new(CandleEmbedder::with_config_and_model(
+            embedding_config,
+            config.model,
+        )?);
 
         // Update HNSW config dimension to match model
         let mut updated_config = config.clone();
@@ -168,7 +170,17 @@ impl DenseSearcher {
                 op: "dense_index_chunk".to_string(),
             });
         }
-        let embedding = self.embedder.embed_query(text).await?;
+        // Documents are embedded verbatim via embed_texts; embed_query would
+        // apply a retrieval query prefix (BGE), corrupting stored vectors.
+        let embedding = self
+            .embedder
+            .embed_texts(&[text])
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                MemdError::EmbeddingError("embed_texts returned no embedding".to_string())
+            })?;
         let index = self.get_or_create_index(tenant_id)?;
         index.insert(chunk_id, &embedding)?;
 

--- a/crates/memd/src/store/hybrid.rs
+++ b/crates/memd/src/store/hybrid.rs
@@ -229,6 +229,7 @@ impl HybridSearcher {
                 ef_search: 30, // Lower than warm tier for faster queries
                 persist_graph_dump: true,
                 search_lock_budget_ms: None,
+                backfill_hnsw_on_startup: false,
             },
             ..Default::default()
         };

--- a/crates/memd/src/store/persistent.rs
+++ b/crates/memd/src/store/persistent.rs
@@ -48,7 +48,7 @@ use super::{
     rank_candidate_chunks, score_candidate_chunk, ExternalMutationOutcome, RywProbeStats, Store,
     StoreHealthSnapshot, StoreStats,
 };
-use crate::embeddings::EmbeddingModel;
+use crate::embeddings::{CandleModel, EmbeddingModel};
 use crate::error::{MemdError, Result};
 use crate::index::{Bm25Index, SparseIndex};
 use crate::metrics::{IndexStats, MetricsCollector, QueryMetrics, TieredQueryMetrics};
@@ -95,7 +95,13 @@ pub struct PersistentStoreConfig {
     /// Hybrid search configuration
     pub hybrid_config: Option<HybridConfig>,
     /// Embedding model to use for dense search
+    ///
+    /// Vestigial ONNX-era selector (retained for config compatibility); the
+    /// live dense embedder is the Candle backend selected via `candle_model`.
     pub embedding_model: EmbeddingModel,
+    /// Candle embedder model actually loaded for dense search. Set from the
+    /// `--embedding-model` CLI choice.
+    pub candle_model: CandleModel,
     /// Enable async/background indexing of newly added chunks
     pub enable_async_indexing: bool,
     /// Max pending chunks processed per async indexer tick
@@ -193,6 +199,7 @@ impl Default for PersistentStoreConfig {
             enable_tiered_search: true,
             hybrid_config: None,
             embedding_model: EmbeddingModel::default(),
+            candle_model: CandleModel::default(),
             enable_async_indexing,
             async_index_batch_size,
             async_index_poll_ms,
@@ -689,7 +696,13 @@ impl PersistentStore {
         let dense_searcher = if config.enable_dense_search {
             use super::dense::DenseSearchConfig;
 
-            let mut dense_config = DenseSearchConfig::default();
+            let mut dense_config = DenseSearchConfig {
+                model: config.candle_model,
+                ..DenseSearchConfig::default()
+            };
+            // Propagate the model-switch migration opt-in so a dimension
+            // mismatch re-embeds from segments instead of hard-erroring.
+            dense_config.hnsw.backfill_hnsw_on_startup = config.backfill_hnsw_on_startup;
             if config.bounded_search_locks {
                 dense_config.hnsw.search_lock_budget_ms = Some(WORKER_SEARCH_LOCK_BUDGET_MS);
             }

--- a/crates/memd/src/tiered/hot_tier.rs
+++ b/crates/memd/src/tiered/hot_tier.rs
@@ -47,6 +47,7 @@ impl Default for HotTierConfig {
                 dimension: 384,
                 persist_graph_dump: true,
                 search_lock_budget_ms: None,
+                backfill_hnsw_on_startup: false,
             },
         }
     }
@@ -355,6 +356,7 @@ mod tests {
                 dimension: 4,
                 persist_graph_dump: true,
                 search_lock_budget_ms: None,
+                backfill_hnsw_on_startup: false,
             },
         }
     }

--- a/crates/memd/tests/hnsw_persistence.rs
+++ b/crates/memd/tests/hnsw_persistence.rs
@@ -1,5 +1,6 @@
 use memd::index::{HnswConfig, HnswIndex};
 use memd::types::ChunkId;
+use memd::MemdError;
 use tempfile::TempDir;
 
 fn normalize(v: &mut [f32]) {
@@ -24,6 +25,7 @@ fn test_hnsw_persistence_round_trip() {
         dimension: 4,
         persist_graph_dump: true,
         search_lock_budget_ms: None,
+        backfill_hnsw_on_startup: false,
     };
 
     // Create index and insert embeddings
@@ -200,18 +202,40 @@ fn test_hnsw_dimension_mismatch() {
     index.save().unwrap();
     drop(index);
 
-    // Try to load with different dimension
+    // Loading with a different dimension (wrong embedding model) must refuse
+    // loudly rather than silently wiping the persisted index.
     let wrong_config = HnswConfig {
         dimension: 8,
         ..Default::default()
     };
+    match HnswIndex::load(&index_path, wrong_config) {
+        Err(MemdError::DenseIndexModelMismatch {
+            store_dim,
+            model_dim,
+            ..
+        }) => {
+            assert_eq!(store_dim, 4);
+            assert_eq!(model_dim, 8);
+        }
+        Err(other) => panic!("expected DenseIndexModelMismatch, got {other:?}"),
+        Ok(_) => panic!("dimension mismatch must error, not silently reset the cache"),
+    }
+    assert!(
+        index_path.join("embeddings.bin").exists(),
+        "refused load must not delete the persisted cache"
+    );
 
-    let loaded = HnswIndex::load(&index_path, wrong_config).unwrap();
-
-    // Should load but with empty cache (dimension mismatch)
+    // Opting into the migration (MEMD_BACKFILL_HNSW_ON_STARTUP=1) re-embeds at
+    // the new dimension, starting from an empty cache.
+    let migrate = HnswConfig {
+        dimension: 8,
+        backfill_hnsw_on_startup: true,
+        ..Default::default()
+    };
+    let loaded = HnswIndex::load(&index_path, migrate).unwrap();
     assert!(
         loaded.cache_is_empty(),
-        "Cache should be empty due to dimension mismatch"
+        "re-embed migration starts from an empty cache"
     );
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,8 +64,11 @@ Unknown keys are silently ignored because the config structs do not deny
 unknown fields.
 
 Retrieval variant is not a config key. Use the global CLI flag
-`--search-variant` with `hybrid-feature` (default), `hybrid-cross-encoder`,
-`dense-only`, or `bm25-only`.
+`--search-variant` with `hybrid-feature`, `hybrid-cross-encoder`,
+`dense-only`, or `bm25-only`. When it is not given, the default is
+model-conditional: `dense-only` for `--embedding-model bge-base`, and
+`hybrid-feature` for `all-minilm` and other models. An explicit
+`--search-variant` always takes precedence.
 
 ## Project alias compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # memd
 
-[![Version](https://img.shields.io/badge/version-1.3.1-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
+[![Version](https://img.shields.io/badge/version-1.4.0-blue)](https://github.com/fmschulz/memd/blob/main/CHANGELOG.md){ .md-button }
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)](https://github.com/fmschulz/memd/blob/main/Cargo.toml){ .md-button }
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/fmschulz/memd/blob/main/LICENSE){ .md-button }
 

--- a/tools/wiki/pyproject.toml
+++ b/tools/wiki/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memd-wiki"
-version = "1.3.1"
+version = "1.4.0"
 description = "Deterministic compiled markdown wiki over memd project state."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Adds **bge-base-en-v1.5** as a first-class Candle-BERT embedder (`--embedding-model bge-base`) and makes **dense-only the default retrieval variant when bge-base is selected** (MiniLM/others keep `hybrid-feature`; an explicit `--search-variant` always wins). Bumps the workspace version to **1.4.0**.

## Why (benchmark)

Mechanistic code-retrieval benchmark (20k CodeXGLUE-python; LLM-as-judge downstream usefulness at n=300/type + paired retrieval CIs):

- **bge dense-only is the best config downstream**: beats hybrid on semantic answer accuracy by **+0.123 [+0.073, +0.173]** (p≈0) and overall by **+0.067 [+0.040, +0.095]**; hybrid fusion never wins with a strong embedder.
- The advantage is **significantly embedder-conditional** — a paired embedder×lane interaction test gives semantic **+0.097 [+0.047, +0.150]**, overall +0.053 [+0.025, +0.082]. Under MiniLM the dense-vs-hybrid gap is small and non-significant (+0.027, p=0.40), so MiniLM keeps the hybrid default (do-no-harm).
- The bge embedder itself is a **+0.101 overall / +0.168 semantic nDCG** retrieval gain vs MiniLM.

## Safety (found in review)

- **Model switch no longer wipes the dense index.** Opening a store built at a different vector dimension (bge 768-d vs MiniLM 384-d) now returns a clear `DenseIndexModelMismatch` error naming both dimensions and the `MEMD_BACKFILL_HNSW_ON_STARTUP=1` migration opt-in, instead of silently deleting the embedding cache. Propagated at the store-open layer so an empty index can't be saved over the real cache; regression-tested there.
- **Warm workers** now carry their embedding model + search variant in the ping identity and respawn on mismatch, instead of silently answering with the wrong embedder.

## Scope

Ships only the bge embedder + dense-only-default coupling. Excludes the benchmark-only adaptive-lanes, whole-code-sparse, and `ef_search` knobs (`ef_search` measured to give ~0 improvement). Default MiniLM behavior is byte-identical.

## Gates

- `cargo build` clean; `cargo test -p memd` **1191 pass / 0 fail**; `cargo fmt --check` clean; version-consistency ✓.
- Independent code+logic review over two rounds; all findings addressed (including the model-switch data-loss guard).

## Release note

Merging to `main` triggers the automated pipeline: `auto-release` tags `v1.4.0` → `publish-crate` publishes to crates.io → cargo-dist builds binaries. CHANGELOG `[1.4.0]` entry included.
